### PR TITLE
Automatically generate table names for uncoupled annotators

### DIFF
--- a/holonote/annotate/table.py
+++ b/holonote/annotate/table.py
@@ -62,6 +62,10 @@ class AnnotationTable(param.Parameterized):
         self._update_index()
 
     def register_annotator(self, annotator):
+
+        if len(self._annotators) >= 1 and list(self._annotators.values())[0].connector.table_name is None:
+            raise Exception("A table_name must be set in the connector when shared across multiple annotators")
+
         self._annotators[id(annotator)] = annotator
 
 

--- a/holonote/tests/test_connectors.py
+++ b/holonote/tests/test_connectors.py
@@ -67,9 +67,6 @@ class TestSQLiteUUIDHexKey(unittest.TestCase):
     def test_setup(self):
         self.assertTrue(self.db.con is not None)
 
-    def test_initialized(self):
-        self.assertFalse(self.db.uninitialized)
-
     def test_add_row(self):
         id1 = self.db.primary_key(self.db)
         start = pd.Timestamp('2022-06-01')
@@ -176,9 +173,6 @@ class TestSQLiteUUIDBinaryKey(unittest.TestCase):
 
     def test_setup(self):
         self.assertTrue(self.db.con is not None)
-
-    def test_initialized(self):
-        self.assertFalse(self.db.uninitialized)
 
     def test_add_row(self):
         id1 = self.db.primary_key(self.db)


### PR DESCRIPTION
This PR fixes the annoying issue of having to delete the (by default) `annotations.db` file every time the schema changes (e.g. in the examples running the two different examples showing time series and image annotations).

This is achieved by figuring out a unique table name based on the schema (i.e. based on the `kdim_dtypes` and declared `fields`). This is only used in the simple case where the connector is automatically created for a single annotator instance: when you share a connector between annotators, you need to give an explicit table name (for one it is better to be explicit and secondly the name would change depending on annotators that get coupled later on).

Currently working but still WIP (want to refactor a little and improve the name generation).