### PR TITLE
Add Python 3.11 to tests and support Pandas 2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v3

--- a/holonote/annotate/table.py
+++ b/holonote/annotate/table.py
@@ -243,7 +243,7 @@ class AnnotationTable(param.Parameterized):
 
     def update_annotation_fields(self, index, **fields):
         for column, value in fields.items():
-            self._field_df.loc[index][column] = value
+            self._field_df.loc[index, column] = value
 
         self._edits.append({'operation':'update', 'id':index,
                             'fields' : [c for c in fields.keys()],
@@ -303,7 +303,7 @@ class AnnotationTable(param.Parameterized):
             raise KeyError(f'Keys {mismatches} do not match any fields entries')
 
         dim2 = None if len(dims)==1 else dims[1]
-        value = zip(posx,  pd.Series([None for el in range(len(posx))])) if len(dims)==1 else zip(posx, posy)
+        value = zip(posx, [None] * len(posx)) if len(dims)==1 else zip(posx, posy)
         additions = pd.DataFrame({"region_type":'Point',
                                   "dim1":dims[0],
                                   "dim2":dim2,

--- a/holonote/tests/test_connectors.py
+++ b/holonote/tests/test_connectors.py
@@ -78,7 +78,7 @@ class TestSQLiteDB:
         end = pd.Timestamp('2022-06-03')
         description = 'A description'
         insertion = {"uuid": id1, 'description':description, 'start':start, 'end':end}
-        df = pd.DataFrame({"uuid":pd.Series([id1], dtype=object),
+        df = pd.DataFrame({"uuid":[database.primary_key.cast(id1)],
                            'description':[description], 'start':[start], 'end':[end]}).set_index("uuid")
         database.add_row(**insertion)
         pd.testing.assert_frame_equal(database.load_dataframe(), df)
@@ -102,10 +102,12 @@ class TestSQLiteDB:
                      'start':pd.Timestamp('2026-06-01'),
                      'end':pd.Timestamp('2026-06-03')}
 
-        df_data = {'uuid': pd.Series([insertion1['uuid'], insertion3['uuid']], dtype=object),
-                   'description':[insertion1['description'], insertion3['description']],
-                   'start':[insertion1['start'], insertion3['start']],
-                   'end':[insertion1['end'], insertion3['end']]}
+        df_data = {
+            'uuid': map(database.primary_key.cast, [insertion1['uuid'], insertion3['uuid']]),
+            'description':[insertion1['description'], insertion3['description']],
+            'start':[insertion1['start'], insertion3['start']],
+            'end':[insertion1['end'], insertion3['end']]
+        }
         df = pd.DataFrame(df_data).set_index('uuid')
         database.add_row(**insertion1)
         database.add_row(**insertion2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",
 ]
-dependencies = ["holoviews", "pandas<2"]
+dependencies = ["holoviews", "pandas"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ source = "vcs"
 [tool.hatch.envs.test]
 dependencies = ["pytest"]
 scripts.run = "python -m pytest holonote/tests"
-matrix = [{ python = ["3.8", "3.9", "3.10"] }]
+matrix = [{ python = ["3.8", "3.9", "3.10", "3.11"] }]
 
 [tool.hatch.envs.fmt]
 dependencies = ["pre-commit"]


### PR DESCRIPTION
Code changes are to support Pandas 2 (see traceback). I tested and confirmed the changes also worked with Pandas 1.

<details>
  <summary>Traceback </summary>


``` python
========================================================================================================================================= FAILURES =========================================================================================================================================
___________________________________________________________________________________________________________________ TestAnnotatorMultipleStringFields.test_commit_update ___________________________________________________________________________________________________________________

self = <test_annotators_advanced.TestAnnotatorMultipleStringFields object at 0x7fa5058d8110>
multiple_fields_annotator = Annotator(_count=0, annotation_table=AnnotationTable(index=['6ac4ef81a1dd41958507ea90f9af5bc8', 'd731cd1d104847e6baf11...numpy.datetime64'>}, name='Annotator00272', rect_max=1050, rect_min=-1000, region_types=['Range'], selected_indices=[])

    def test_commit_update(self, multiple_fields_annotator):
        start1, end1  = np.datetime64('2022-06-06'), np.datetime64('2022-06-08')
        start2, end2  = np.datetime64('2023-06-06'), np.datetime64('2023-06-08')
        multiple_fields_annotator.set_range(start1, end1)
        multiple_fields_annotator.add_annotation(field1='Field 1.1', field2='Field 1.2')
        multiple_fields_annotator.set_range(start2, end2)
        multiple_fields_annotator.add_annotation(field1='Field 2.1', field2='Field 2.2')
        multiple_fields_annotator.commit(return_commits=True)
        multiple_fields_annotator.update_annotation_fields(multiple_fields_annotator.df.index[0], field1='NEW Field 1.1')
        multiple_fields_annotator.commit(return_commits=True)
        sql_df = multiple_fields_annotator.connector.load_dataframe()
>       assert set(sql_df['field1']) == {'NEW Field 1.1', 'Field 2.1'}
E       AssertionError: assert {'Field 1.1', 'Field 2.1'} == {'NEW Field 1.1', 'Field 2.1'}
E         Extra items in the left set:
E         'Field 1.1'
E         Extra items in the right set:
E         'NEW Field 1.1'
E         Full diff:
E         - {'NEW Field 1.1', 'Field 2.1'}
E         + {'Field 1.1', 'Field 2.1'}

holonote/tests/test_annotators_advanced.py:100: AssertionError
_______________________________________________________________________________________________________________________ TestSQLiteDB.test_add_row[AutoIncrementKey] ________________________________________________________________________________________________________________________

self = <test_connectors.TestSQLiteDB object at 0x7fa505709cd0>
database = SQLiteDB(column_schema={'uuid': 'INTEGER PRIMARY KEY AUTOINCREMENT', 'description': 'TEXT', 'start': 'TIMESTAMP', 'end...80>, 'save': <function Connector.<lambda> at 0x7fa50587e020>, 'load': <function Connector.<lambda> at 0x7fa50587e0c0>})
request = <FixtureRequest for <Function test_add_row[AutoIncrementKey]>>

    def test_add_row(self, database, request):
        id1 = database.primary_key(database)
        start = pd.Timestamp('2022-06-01')
        end = pd.Timestamp('2022-06-03')
        description = 'A description'
        insertion = {"uuid": id1, 'description':description, 'start':start, 'end':end}
        df = pd.DataFrame({"uuid":pd.Series([id1], dtype=object),
                           'description':[description], 'start':[start], 'end':[end]}).set_index("uuid")
        database.add_row(**insertion)
>       pd.testing.assert_frame_equal(database.load_dataframe(), df)

holonote/tests/test_connectors.py:84: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

left = Index([1], dtype='int64', name='uuid'), right = Index([1], dtype='object', name='uuid'), obj = 'DataFrame.index'

    def _check_types(left, right, obj: str = "Index") -> None:
        if not exact:
            return
    
        assert_class_equal(left, right, exact=exact, obj=obj)
        assert_attr_equal("inferred_type", left, right, obj=obj)
    
        # Skip exact dtype checking when `check_categorical` is False
        if is_categorical_dtype(left.dtype) and is_categorical_dtype(right.dtype):
            if check_categorical:
                assert_attr_equal("dtype", left, right, obj=obj)
                assert_index_equal(left.categories, right.categories, exact=exact)
            return
    
>       assert_attr_equal("dtype", left, right, obj=obj)
E       AssertionError: DataFrame.index are different
E       
E       Attribute "dtype" are different
E       [left]:  int64
E       [right]: object

../../../miniconda3/envs/holoviz/lib/python3.11/site-packages/pandas/_testing/asserters.py:250: AssertionError
______________________________________________________________________________________________________________ TestSQLiteDB.test_add_three_rows_delete_one[AutoIncrementKey] _______________________________________________________________________________________________________________

self = <test_connectors.TestSQLiteDB object at 0x7fa50570ad90>
database = SQLiteDB(column_schema={'uuid': 'INTEGER PRIMARY KEY AUTOINCREMENT', 'description': 'TEXT', 'start': 'TIMESTAMP', 'end...80>, 'save': <function Connector.<lambda> at 0x7fa50587e020>, 'load': <function Connector.<lambda> at 0x7fa50587e0c0>})

    def test_add_three_rows_delete_one(self, database):
        id1 = database.primary_key(database)
        insertion1 = {'uuid': id1,
                     'description':'A description',
                     'start':pd.Timestamp('2022-06-01'),
                     'end':pd.Timestamp('2022-06-03')}
    
        id2 = database.primary_key(database, [id1])
        insertion2 = {'uuid': id2,
                     'description':'A 2nd description',
                     'start':pd.Timestamp('2024-06-01'),
                     'end':pd.Timestamp('2024-06-03')}
    
        id3 = database.primary_key(database, [id2])
        insertion3 = {'uuid': id3,
                     'description':'A 3rd description',
                     'start':pd.Timestamp('2026-06-01'),
                     'end':pd.Timestamp('2026-06-03')}
    
        df_data = {'uuid': pd.Series([insertion1['uuid'], insertion3['uuid']], dtype=object),
                   'description':[insertion1['description'], insertion3['description']],
                   'start':[insertion1['start'], insertion3['start']],
                   'end':[insertion1['end'], insertion3['end']]}
        df = pd.DataFrame(df_data).set_index('uuid')
        database.add_row(**insertion1)
        database.add_row(**insertion2)
        database.add_row(**insertion3)
        database.delete_row(id2)
>       pd.testing.assert_frame_equal(database.load_dataframe(), df)

holonote/tests/test_connectors.py:114: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

left = Index([1, 3], dtype='int64', name='uuid'), right = Index([1, 3], dtype='object', name='uuid'), obj = 'DataFrame.index'

    def _check_types(left, right, obj: str = "Index") -> None:
        if not exact:
            return
    
        assert_class_equal(left, right, exact=exact, obj=obj)
        assert_attr_equal("inferred_type", left, right, obj=obj)
    
        # Skip exact dtype checking when `check_categorical` is False
        if is_categorical_dtype(left.dtype) and is_categorical_dtype(right.dtype):
            if check_categorical:
                assert_attr_equal("dtype", left, right, obj=obj)
                assert_index_equal(left.categories, right.categories, exact=exact)
            return
    
>       assert_attr_equal("dtype", left, right, obj=obj)
E       AssertionError: DataFrame.index are different
E       
E       Attribute "dtype" are different
E       [left]:  int64
E       [right]: object

../../../miniconda3/envs/holoviz/lib/python3.11/site-packages/pandas/_testing/asserters.py:250: AssertionError
===================================================================================================================================== warnings summary =====================================================================================================================================
holonote/tests/test_annotators_advanced.py::TestAnnotatorMultipleStringFields::test_commit_update
  /home/shh/Repos/holoviz/holonote/holonote/annotate/table.py:246: SettingWithCopyWarning: 
  A value is trying to be set on a copy of a slice from a DataFrame
  
  See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
    self._field_df.loc[index][column] = value

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================================================= short test summary info ==================================================================================================================================
FAILED holonote/tests/test_annotators_advanced.py::TestAnnotatorMultipleStringFields::test_commit_update - AssertionError: assert {'Field 1.1', 'Field 2.1'} == {'NEW Field 1.1', 'Field 2.1'}
FAILED holonote/tests/test_connectors.py::TestSQLiteDB::test_add_row[AutoIncrementKey] - AssertionError: DataFrame.index are different
FAILED holonote/tests/test_connectors.py::TestSQLiteDB::test_add_three_rows_delete_one[AutoIncrementKey] - AssertionError: DataFrame.index are different
```

</details>