### PR TITLE
Use annotators fields if none is provided to the connector

### DIFF
--- a/holonote/annotate/annotator.py
+++ b/holonote/annotate/annotator.py
@@ -116,6 +116,8 @@ class AnnotatorInterface(param.Parameterized):
         spec = self.normalize_spec(spec)
 
         super().__init__(spec=spec, connector=connector, **params)
+        if connector.fields is None:
+            connector.fields = self.fields
         self._region = {}
         self._last_region = None
         self.annotation_table = AnnotationTable()

--- a/holonote/annotate/connector.py
+++ b/holonote/annotate/connector.py
@@ -144,8 +144,7 @@ class Connector(param.Parameterized):
 
     commit_hook = param.Parameter(default=None, doc='Callback, applies default schema if None')
 
-    fields = param.List(default=['description'], doc='''
-      List of column names for domain-specific fields''')
+    fields = param.List(default=None, doc='List of column names for domain-specific fields')
 
     transforms = param.Dict(default={'insert':lambda x: x,
                                      'update':lambda x: x ,

--- a/holonote/tests/test_annotators_basic.py
+++ b/holonote/tests/test_annotators_basic.py
@@ -6,12 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-# TODO:
-
-# * (after refactor) annotators -> annotator, connectors -> connector [ ]
-# TESTS
-# Schema error (needs file or connect in memory??)
-# .snapshot() and .revert_to_snapshot()
+from holonote.annotate import Annotator
 
 
 class TestBasicRange1DAnnotator:
@@ -452,3 +447,18 @@ class TestBasicPoint2DAnnotator:
         annotator_point2d.define_fields(data1[['description']])
         with pytest.raises(KeyError, match=str(mismatched)):
             annotator_point2d.define_points(data2['xs'], data2['ys'])
+
+
+@pytest.mark.parametrize('fields', (["test"], ["test1", "test2"]))
+def test_connector_use_annotator_fields(conn_sqlite_uuid, fields):
+    annotator = Annotator({"TIME": float}, connector=conn_sqlite_uuid, fields=fields)
+
+    assert annotator.fields == fields
+    assert annotator.connector.fields == fields
+
+
+def test_connector_use_annotator_fields_default(conn_sqlite_uuid):
+    annotator = Annotator({"TIME": float}, connector=conn_sqlite_uuid)
+
+    assert annotator.fields == ["description"]
+    assert annotator.connector.fields == ["description"]


### PR DESCRIPTION
I'm not sure we should keep having fields in the `Connector`. 

This makes it possible to do this:
``` python
from holonote.annotate import Annotator, SQLiteDB

fields = ["ProductionStoppage", "Reason", "Category"]
connector = SQLiteDB(filename=":memory:")
# instead of 
# connector = SQLiteDB(filename=":memory:", fields=fields)

annotator = Annotator({"TIME": float}, fields=fields, connector=connector)