### PR TITLE
Clear region after using define_annotations

### DIFF
--- a/holonote/annotate/annotator.py
+++ b/holonote/annotate/annotator.py
@@ -312,6 +312,9 @@ class AnnotatorInterface(param.Parameterized):
             self._set_regions(**regions)
             self._add_annotation(**fields)
 
+        # See: https://github.com/holoviz/holonote/pull/50
+        self.clear_regions()
+
     # Snapshotting and reverting
     @property
     def has_snapshot(self) -> bool:

--- a/holonote/tests/test_annotators_advanced.py
+++ b/holonote/tests/test_annotators_advanced.py
@@ -234,3 +234,12 @@ def test_define_annotations_with_multiple_field_warn(conn_sqlite_uuid) -> None:
         annotator.define_annotations(
             pd.DataFrame(data), TIME=("start_number", "end_number"), description="category"
         )
+
+
+def test_define_annotations_clear_region(conn_sqlite_uuid) -> None:
+    # See: https://github.com/holoviz/holonote/pull/50
+    annotator = Annotator({"x": float}, connector=conn_sqlite_uuid)
+    data = {"description": ["A", "B"], "start_number": [0.1, 0.5], "end_number": [0.4, 0.8]}
+    annotator.define_annotations(pd.DataFrame(data), x=("start_number", "end_number"))
+    assert annotator.region == {}
+    assert annotator._last_region == {}


### PR DESCRIPTION
It would give some unintuitive behavior:

``` python
import holoviews as hv
import pandas as pd

from holonote.annotate import Annotator, SQLiteDB

hv.extension("bokeh")

connector = SQLiteDB(filename=":memory:")
annotator = Annotator({"x": float}, connector=connector)
data = {"description": ["A", "B"], "start_number": [0.1, 0.5], "end_number": [0.4, 0.8]}
annotator.define_annotations(pd.DataFrame(data), x=("start_number", "end_number"))

hv.Curve([]) * annotator
```

Before:

https://github.com/holoviz/holonote/assets/19758978/d30d6f6e-d4e7-4a37-8fb7-09068d7d8bc9

After:



https://github.com/holoviz/holonote/assets/19758978/e4c374ad-18e0-41b6-bba0-5e7012fc157f

