### PR TITLE
Fixed inheritance declaration of PanelWidgets

### DIFF
--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -5,6 +5,7 @@ import datetime as dt
 from typing import TYPE_CHECKING, Any
 
 import panel as pn
+from panel.viewable import Viewer
 import param
 from packaging.version import Version
 
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
 PN13 = Version(pn.__version__) >= Version("1.3.0")
 
 
-class PanelWidgets:
+class PanelWidgets(Viewer):
     mapping = {
         str: pn.widgets.TextInput,
         bool: pn.widgets.Checkbox,

--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -5,9 +5,9 @@ import datetime as dt
 from typing import TYPE_CHECKING, Any
 
 import panel as pn
-from panel.viewable import Viewer
 import param
 from packaging.version import Version
+from panel.viewable import Viewer
 
 if TYPE_CHECKING:
     from holonote.annotate import Annotator


### PR DESCRIPTION
The `__panel__` method isn't useful unless the class inherits from `Viewer`.