### PR TITLE
Reduce updating triggers for displays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ __pycache__/
 .ipynb_checkpoints/
 .pytest_cache
 dist
-scratch/
+scratch
 holonote/_version.py

--- a/holonote/annotate/annotator.py
+++ b/holonote/annotate/annotator.py
@@ -117,7 +117,7 @@ class AnnotatorInterface(param.Parameterized):
 
     # Selecting annotations
 
-    def select_by_index(self, *inds):
+    def select_by_index(self, *inds) -> None:
         "Set the selection state by the indices i.e. primary key values"
         self.selected_indices = list(inds)
 
@@ -346,20 +346,6 @@ class Annotator(AnnotatorInterface):
             super().delete_annotation(index)
         self.refresh()
 
-    def select_by_index(self, *inds):
-        "Set the selection state by the indices i.e. primary key values"
-
-        for v in self._displays.values():
-            if not v.selection_enabled:
-                inds = ()
-
-            for d, val in zip(v._selected_options, v._selected_values):
-                d.clear()
-                for ind in inds:
-                    d[ind] = val
-        super().select_by_index(*inds)
-        self.refresh()
-
     def define_annotations(self, data: pd.DataFrame, **kwargs) -> None:
         super().define_annotations(data, **kwargs)
         self.refresh(clear=True)
@@ -393,7 +379,7 @@ class Annotator(AnnotatorInterface):
         for v in self._displays.values():
             v.editable_enabled = enabled
 
-    @param.depends("style.param", "groupby", "visible", watch=True)
+    @param.depends("style.param", "groupby", "visible", "selected_indices", watch=True)
     def _refresh_style(self) -> None:
         self.refresh()
 

--- a/holonote/annotate/annotator.py
+++ b/holonote/annotate/annotator.py
@@ -379,7 +379,7 @@ class Annotator(AnnotatorInterface):
         for v in self._displays.values():
             v.editable_enabled = enabled
 
-    @param.depends("style.param", "groupby", "visible", "selected_indices", watch=True)
+    @param.depends("style.param", "groupby", "visible", watch=True)
     def _refresh_style(self) -> None:
         self.refresh()
 

--- a/holonote/annotate/annotator.py
+++ b/holonote/annotate/annotator.py
@@ -304,6 +304,7 @@ class Annotator(AnnotatorInterface):
 
     def refresh(self, clear=False) -> None:
         for v in self._displays.values():
+            v._update_data()
             hv.streams.Stream.trigger([v._annotation_count_stream])
             if clear:
                 v.clear_indicated_region()

--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -216,8 +216,6 @@ class AnnotationDisplay(param.Parameterized):
 
         self._selection_enabled = True
         self._editable_enabled = True
-        self._selected_values = []
-        self._selected_options = []
 
         transient = False
         self._edit_streams = [
@@ -499,17 +497,10 @@ class AnnotationDisplay(param.Parameterized):
 
         return indicator.overlay() if self.annotator.groupby else hv.NdOverlay({0: indicator})
 
-    def selected_dim_expr(self, selected_value, non_selected_value):
-        self._selected_values.append(selected_value)
-        self._selected_options.append({i: selected_value for i in self.annotator.selected_indices})
-        index_name = (
-            "id"
-            if self.annotator.annotation_table._field_df.index.name is None
-            else self.annotator.annotation_table._field_df.index.name
-        )
-        return hv.dim(index_name).categorize(
-            self._selected_options[-1], default=non_selected_value
-        )
+    def selected_dim_expr(self, selected_value, non_selected_value) -> hv.dim:
+        selected_options = dict.fromkeys(self.annotator.selected_indices, selected_value)
+        index_name = self.data.index.name or "id"
+        return hv.dim(index_name).categorize(selected_options, default=non_selected_value)
 
     @property
     def dim_expr(self):

--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -438,10 +438,12 @@ class AnnotationDisplay(param.Parameterized):
         self.register_tap_selector(self._element)
         self.register_double_tap_clear(self._element)
 
-        def inner(_count):
+        def inner(_count, selected_indices):
             return self.static_indicators
 
-        return hv.DynamicMap(inner, streams=[self._annotation_count_stream])
+        return hv.DynamicMap(
+            inner, streams=[self._annotation_count_stream, self.annotator.param.selected_indices]
+        )
 
     def overlay(self, indicators=True, editor=True) -> hv.Overlay:
         layers = []

--- a/holonote/annotate/table.py
+++ b/holonote/annotate/table.py
@@ -288,7 +288,7 @@ class AnnotationTable(param.Parameterized):
         field_df = self._field_df
         region_df = self._expand_region_df(spec=spec, dims=dims)
 
-        df = region_df.merge(field_df, left_index=True, right_index=True, how="left")
+        df = region_df.join(field_df, how="left")
         df.index.name = self._field_df.index.name
         df = df.reindex(field_df.index)
         return df


### PR DESCRIPTION
This will now only update the data of the display each time a `refresh()` is done and only refresh when `selected_indexes` is changed.


Something like this would run `self.annotator.get_dataframe` 5 times with each click on a curve. If I commented out the `anno2` line, it would be 3 times. After this change, it will only run once, and not update when clicking (as the data has not changed).


``` python
from __future__ import annotations

import holoviews as hv
import panel as pn

from holonote.annotate import Annotator, SQLiteDB
from holonote.app import PanelWidgets

hv.extension("bokeh")

# connector = SQLiteDB(filename=":memory:")
connector = SQLiteDB(table_name="test_curves")

annotator = Annotator({"TIME": float}, fields=["description"], connector=connector)
anno1 = annotator * hv.Curve(range(10), kdims="TIME")
anno2 = annotator * hv.Curve(range(10)[::-1], kdims="TIME")
anno = anno1

b = PanelWidgets(annotator)
pn.Row(b, anno).servable()
```