### PR TITLE
Performance improvements related to static_indicators

### DIFF
--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -405,15 +405,15 @@ class AnnotationDisplay(param.Parameterized):
         return element
 
     def indicators(self) -> hv.DynamicMap:
-        self.register_tap_selector(self._element)
-        self.register_double_tap_clear(self._element)
+        if not hasattr(self, "_indicators"):
+            self.register_tap_selector(self._element)
+            self.register_double_tap_clear(self._element)
 
-        def inner(_count, selected_indices):
-            return self.static_indicators()
-
-        return hv.DynamicMap(
-            inner, streams=[self._annotation_count_stream, self.annotator.param.selected_indices]
-        )
+            self._indicators = hv.DynamicMap(
+                self.static_indicators,
+                streams=[self._annotation_count_stream, self.annotator.param.selected_indices],
+            )
+        return self._indicators
 
     def overlay(self, indicators=True, editor=True) -> hv.Overlay:
         layers = []
@@ -430,7 +430,7 @@ class AnnotationDisplay(param.Parameterized):
             layers.append(self.region_editor())
         return hv.Overlay(layers).collate()
 
-    def static_indicators(self):
+    def static_indicators(self, **events):
         fields_labels = self.annotator.all_fields
         region_labels = [k for k in self.data.columns if k not in fields_labels]
 

--- a/holonote/tests/util.py
+++ b/holonote/tests/util.py
@@ -20,5 +20,5 @@ def get_editor(annotator, element_type, kdims=None):
 
 
 def get_indicator(annotator, element_type, kdims=None):
-    si = _get_display(annotator, kdims).static_indicators
+    si = _get_display(annotator, kdims).static_indicators()
     yield from si.data.values()

--- a/holonote/tests/util.py
+++ b/holonote/tests/util.py
@@ -20,5 +20,5 @@ def get_editor(annotator, element_type, kdims=None):
 
 
 def get_indicator(annotator, element_type, kdims=None):
-    si = _get_display(annotator, kdims).static_indicators()
+    si = _get_display(annotator, kdims).indicators().last
     yield from si.data.values()


### PR DESCRIPTION
Having `static_indicator` as a property "hides" that it recreates a new element each time.  

I have simplified the logic by removing duplicated code and updated `get_indices_by_position` to no longer use `self.static_indicator.data`. Instead, it now uses the already available data.

Also, change `static_indicator` to a normal method and only create indicators once. 