### PR TITLE
Add types

### DIFF
--- a/holonote/annotate/connector.py
+++ b/holonote/annotate/connector.py
@@ -166,22 +166,28 @@ class Connector(param.Parameterized):
 
     operation_mapping = {}  # Mapping from operation type to corresponding connector method
 
+    # iterate on all the possible types
     type_mapping = {
         bool: "BOOLEAN",
         str: "TEXT",
         float: "REAL",
         int: "INTEGER",
-        np.datetime64: "TIMESTAMP",
         dt.date: "TIMESTAMP",
         dt.datetime: "TIMESTAMP",
-        param.Integer: "INTEGER",
-        param.Number: "REAL",
-        param.String: "TEXT",
-        param.Boolean: "BOOLEAN",
+        pd.Timedelta: "INTEGER",
+        pd.Timestamp: "TIMESTAMP",
         np.dtype("datetime64[ns]"): "TIMESTAMP",
         np.dtype("<M8"): "TIMESTAMP",
         np.float64: "REAL",
+        np.float32: "REAL",
+        np.float16: "REAL",
+        np.int8: "INTEGER",
+        np.int16: "INTEGER",
+        np.int32: "INTEGER",
         np.int64: "INTEGER",
+        np.uint8: "INTEGER",
+        np.uint16: "INTEGER",
+        np.uint32: "INTEGER",
     }
 
     @classmethod


### PR DESCRIPTION
I combed through the pandas library trying to find the optimal solution for converting python/pandas/numpy dtypes into corresponding SQL types--each with its own trade-offs. In the end, since I don't knowing too much of HoloNote's internals, specifically whether I can update SpecItem, or how much of HoloNote I should change (can we completely remove SQLiteDB(Connector) from connector.py and use SQLAlchemy?), I chose the most compatible path forward. However, I list my notes below:

```python
# 1 doesn't touch internal method, but needs to parse the CREATE TABLE string to get schema
# Outputs: `CREATE TABLE "test" (\n"index" INTEGER,\n  "a" INTEGER,\n  "b" REAL,\n  "c" TEXT,\n  "d"...``
table = pd.io.sql.SQLiteTable("test", None, frame=df)
table.sql_schema()
```

```python
# 2 touches internal method, and not sure where to inject inside HoloNote
# however, for sqlalchemy, table._sql_type_name is _sqlalchemy_type
table = pd.io.sql.SQLiteTable("test", None, frame=df)
print(table._get_column_names_and_types(table._sql_type_name))
```

```python
# 3 still need to use mapper, and not sure where to inject inside HoloNote
for col in df.columns:
    try:
        print(col, type(df[col][0]), pd.api.types.pandas_dtype(type(df[col][0])))
    except Exception as e:
        print(col, type(df[col][0]), "FAILED")
        continue
```

```python
# 4 still needs to use mapper and not sure where to inject inside HoloNote
for col in df.columns:
    print(pd.api.types.infer_dtype(df[col]))
```

# 5 include SQLAlchemy dependency

# 6 include pyarrow dependency
```
I was also wondering why we need to have the connector `SQLiteDB.create_table` define the types inside? Why not have `df.to_sql()` figure it out?

Also, do we need a Connector class or can we depend on SQLAlchemy's classes?