### PR TITLE
Don't send `None` values to the database when adding new rows

### DIFF
--- a/holonote/annotate/annotator.py
+++ b/holonote/annotate/annotator.py
@@ -190,6 +190,7 @@ class AnnotatorInterface(param.Parameterized):
 
     def add_annotation(self, **fields):
         self._add_annotation(**fields)
+        self.clear_regions()
 
     def update_annotation_region(self, index):
         self.annotation_table.update_annotation_region(self._region, index)

--- a/holonote/annotate/connector.py
+++ b/holonote/annotate/connector.py
@@ -498,11 +498,10 @@ class _SQLiteDB(Connector):
 
         placeholders = ", ".join(["?"] * len(field_values))
         column_str = ", ".join(map(_get_valid_sqlite_name, columns))
-        self.execute(
-            f"INSERT INTO {self._safe_table_name} ({column_str}) VALUES({placeholders});",
-            field_values,
-        )
-        # self.primary_key.validate(self.cursor.lastrowid, fields[self.primary_key.field_name])
+        query = f"INSERT INTO {self._safe_table_name} ({column_str}) VALUES({placeholders});"
+        with self.run_transaction() as cursor:
+            cursor.execute(query, field_values)
+            self.primary_key.validate(cursor.lastrowid, fields[self.primary_key.field_name])
 
     def delete_all_rows(self):
         "Obviously a destructive operation!"

--- a/holonote/annotate/connector.py
+++ b/holonote/annotate/connector.py
@@ -6,6 +6,7 @@ import os
 import sqlite3
 import sys
 import uuid
+from contextlib import contextmanager
 from functools import cache
 from pathlib import Path
 from shutil import copyfile
@@ -385,17 +386,32 @@ class _SQLiteDB(Connector):
             column_schema = {}
 
         params["column_schema"] = column_schema
-        self.con, self.cursor = None, None
+        self.con = None
         super().__init__(**params)
 
         if connect:
             self._initialize(column_schema, create_table=False)
 
+    @contextmanager
+    def run_transaction(self):
+        cur = self.con.cursor()
+        try:
+            yield cur
+            self.con.commit()
+        except Exception:
+            self.con.rollback()
+            raise
+        finally:
+            cur.close()
+
+    def execute(self, query, *args):
+        with self.run_transaction() as cursor:
+            return cursor.execute(query, *args)
+
     def _initialize(self, column_schema, create_table=True):
         _sqlite_adapters()
         if self.con is None:
             self.con = self._create_database_connection()
-            self.cursor = self.con.cursor()  # should be context manager
         if create_table:
             if self.table_name is None:
                 self.table_name = self._generate_table_name(column_schema)
@@ -427,44 +443,45 @@ class _SQLiteDB(Connector):
     @property
     def columns(self):
         "Return names of columns"
-        result = self.cursor.execute("PRAGMA table_info('%s')" % self.table_name).fetchall()
+        with self.run_transaction() as cursor:
+            result = cursor.execute(f"PRAGMA table_info({self._safe_table_name})").fetchall()
         return list(zip(*result))[1]
 
     def max_rowid(self):
-        return self.cursor.execute(f"SELECT max(ROWID) from {self.table_name}").fetchone()[0]
+        with self.run_transaction() as cursor:
+            return cursor.execute(f"SELECT max(ROWID) from {self._safe_table_name}").fetchone()[0]
 
     def initialize(self, column_schema):
         self.column_schema = column_schema
         self._initialize(column_schema)
 
     def load_dataframe(self):
-        uninitialized = self.cursor is None
-        if uninitialized:
-            self._initialize({}, create_table=False)
+        # uninitialized = self.cursor is None
+        # if uninitialized:
+        #     self._initialize({}, create_table=False)
 
         raw_df = pd.read_sql_query(f"SELECT * FROM {self._safe_table_name}", self.con)
         # dtype={self.primary_key.field_name:self.primary_key.dtype})
         df = raw_df.set_index(self.primary_key.field_name)
-        if uninitialized:
-            self.con, self.cursor = None, None
+        # if uninitialized:
+        #     self.con, self.cursor = None, None
         return df
 
     def get_tables(self):
-        res = self.cursor.execute("SELECT name FROM sqlite_master")
-        return [el[0] for el in res.fetchmany()]
+        with self.run_transaction() as cursor:
+            res = cursor.execute("SELECT name FROM sqlite_master").fetchmany()
+        return [el[0] for el in res]
 
     def create_table(self, column_schema=None):
         column_schema = column_schema if column_schema else self.column_schema
         column_spec = ",\n".join(
             [f"{_get_valid_sqlite_name(name)} {spec}" for name, spec in column_schema.items()]
         )
-        create_table_sql = f"CREATE TABLE IF NOT EXISTS {self._safe_table_name} ({column_spec});"
-        self.cursor.execute(create_table_sql)
-        self.con.commit()
+        query = f"CREATE TABLE IF NOT EXISTS {self._safe_table_name} ({column_spec});"
+        self.execute(query)
 
     def delete_table(self):
-        self.cursor.execute(f"DROP TABLE IF EXISTS {self._safe_table_name}")
-        self.con.commit()
+        self.execute(f"DROP TABLE IF EXISTS {self._safe_table_name}")
 
     def add_rows(self, field_list):  # Used execute_many
         for field in field_list:
@@ -481,32 +498,28 @@ class _SQLiteDB(Connector):
 
         placeholders = ", ".join(["?"] * len(field_values))
         column_str = ", ".join(map(_get_valid_sqlite_name, columns))
-        self.cursor.execute(
+        self.execute(
             f"INSERT INTO {self._safe_table_name} ({column_str}) VALUES({placeholders});",
             field_values,
         )
-        self.primary_key.validate(self.cursor.lastrowid, fields[self.primary_key.field_name])
-        self.con.commit()
+        # self.primary_key.validate(self.cursor.lastrowid, fields[self.primary_key.field_name])
 
     def delete_all_rows(self):
         "Obviously a destructive operation!"
-        self.cursor.execute(f"DELETE FROM {self._safe_table_name};")
-        self.con.commit()
+        self.execute(f"DELETE FROM {self._safe_table_name};")
 
     def delete_row(self, id_val):
-        self.cursor.execute(
+        self.execute(
             f"DELETE FROM {self._safe_table_name} WHERE {self.primary_key.field_name} = ?",
             (self.primary_key.cast(id_val),),
         )
-        self.con.commit()
 
     def update_row(self, **updates):  # updates as a dictionary OR remove posarg?
         assert self.primary_key.field_name in updates
         id_val = updates.pop(self.primary_key.field_name)
         set_updates = ", ".join('"' + k + '"' + " = ?" for k in updates)
         query = f'UPDATE {self._safe_table_name} SET {set_updates} WHERE "{self.primary_key.field_name}" = ?;'
-        self.cursor.execute(query, [*updates.values(), id_val])
-        self.con.commit()
+        self.execute(query, [*updates.values(), id_val])
 
 
 class _SQLiteDBJupyterLite(_SQLiteDB):

--- a/holonote/annotate/connector.py
+++ b/holonote/annotate/connector.py
@@ -477,18 +477,17 @@ class _SQLiteDB(Connector):
             self.add_row(**field)
 
     def add_row(self, **fields):
-        columns = list(fields.keys())
-        field_values = list(fields.values())
+        columns, parameters = zip(*fields.items())
 
         if self.primary_key.policy != "insert":
-            field_values = field_values[1:]
             columns = columns[1:]
+            parameters = parameters[1:]
 
-        placeholders = ", ".join(["?"] * len(field_values))
+        placeholders = ", ".join(["?"] * len(parameters))
         column_str = ", ".join(map(_get_valid_sqlite_name, columns))
         query = f"INSERT INTO {self._safe_table_name} ({column_str}) VALUES({placeholders});"
         with self.run_transaction() as cursor:
-            cursor.execute(query, field_values)
+            cursor.execute(query, parameters)
             self.primary_key.validate(cursor.lastrowid, fields[self.primary_key.field_name])
 
     def delete_all_rows(self):

--- a/holonote/annotate/connector.py
+++ b/holonote/annotate/connector.py
@@ -408,6 +408,10 @@ class _SQLiteDB(Connector):
         with self.run_transaction() as cursor:
             return cursor.execute(query, *args)
 
+    def close(self):
+        self.con.close()
+        self.con = None
+
     def _initialize(self, column_schema, create_table=True):
         _sqlite_adapters()
         if self.con is None:
@@ -546,7 +550,7 @@ class _SQLiteDBJupyterLite(_SQLiteDB):
             factory=CopyConnection,
             detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
         )
-        con.execute("PRAGMA journal_mode=WAL;")
+        self.execute("PRAGMA journal_mode=WAL;")
         return con
 
 

--- a/holonote/annotate/connector.py
+++ b/holonote/annotate/connector.py
@@ -386,7 +386,7 @@ class _SQLiteDB(Connector):
             column_schema = {}
 
         params["column_schema"] = column_schema
-        self.con, self._columns = None, None
+        self.con = None
         super().__init__(**params)
 
         if connect:
@@ -411,7 +411,6 @@ class _SQLiteDB(Connector):
     def close(self):
         self.con.close()
         self.con = None
-        self._columns = None
 
     def _initialize(self, column_schema, create_table=True):
         _sqlite_adapters()
@@ -444,17 +443,6 @@ class _SQLiteDB(Connector):
         if self.con is not None:
             return self.table_name not in self.get_tables()
         return True
-
-    @property
-    def columns(self):
-        "Return names of columns"
-        if self._columns is not None:
-            return self._columns
-
-        with self.run_transaction() as cursor:
-            result = cursor.execute(f"PRAGMA table_info({self._safe_table_name})").fetchall()
-        self._columns = list(zip(*result))[1]
-        return self._columns
 
     def max_rowid(self):
         with self.run_transaction() as cursor:
@@ -489,9 +477,8 @@ class _SQLiteDB(Connector):
             self.add_row(**field)
 
     def add_row(self, **fields):
-        # Note, missing fields will be set as NULL
-        columns = self.columns
-        field_values = [fields.get(col, None) for col in self.columns]
+        columns = list(fields.keys())
+        field_values = list(fields.values())
 
         if self.primary_key.policy != "insert":
             field_values = field_values[1:]

--- a/holonote/annotate/connector.py
+++ b/holonote/annotate/connector.py
@@ -533,7 +533,6 @@ class _SQLiteDBJupyterLite(_SQLiteDB):
             factory=CopyConnection,
             detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
         )
-        self.execute("PRAGMA journal_mode=WAL;")
         return con
 
 

--- a/holonote/annotate/connector.py
+++ b/holonote/annotate/connector.py
@@ -404,9 +404,9 @@ class _SQLiteDB(Connector):
         finally:
             cur.close()
 
-    def execute(self, query, *args):
+    def execute(self, query, *args) -> None:
         with self.run_transaction() as cursor:
-            return cursor.execute(query, *args)
+            cursor.execute(query, *args)
 
     def close(self):
         self.con.close()
@@ -465,16 +465,8 @@ class _SQLiteDB(Connector):
         self._initialize(column_schema)
 
     def load_dataframe(self):
-        # uninitialized = self.cursor is None
-        # if uninitialized:
-        #     self._initialize({}, create_table=False)
-
         raw_df = pd.read_sql_query(f"SELECT * FROM {self._safe_table_name}", self.con)
-        # dtype={self.primary_key.field_name:self.primary_key.dtype})
-        df = raw_df.set_index(self.primary_key.field_name)
-        # if uninitialized:
-        #     self.con, self.cursor = None, None
-        return df
+        return raw_df.set_index(self.primary_key.field_name)
 
     def get_tables(self):
         with self.run_transaction() as cursor:

--- a/holonote/tests/test_annotators_basic.py
+++ b/holonote/tests/test_annotators_basic.py
@@ -346,13 +346,22 @@ def test_spec_datetime_date(conn_sqlite_uuid, dtype):
     assert output["end[time]"] == np.dtype("datetime64[ns]")
 
 
-def test_multiple_regions_one_first(multiple_annotators, conn_sqlite_uuid):
+def test_multiple_regions_one_first(multiple_annotators):
     annotator = multiple_annotators
 
     annotator.set_regions(TIME=(pd.Timestamp("2022-06-06"), pd.Timestamp("2022-06-08")))
     annotator.add_annotation(description="Only time")
-    annotator.commit()
+    commit = annotator.commit(return_commits=True)
+    assert set(commit[0]["kwargs"]) == {"start_TIME", "end_TIME", "description", "uuid"}
 
     annotator.set_regions(x=(-0.25, 0.25), y=(-0.1, 0.1))
     annotator.add_annotation(description="x and y")
-    annotator.commit()
+    commit = annotator.commit(return_commits=True)
+    assert set(commit[0]["kwargs"]) == {
+        "start_x",
+        "end_x",
+        "start_y",
+        "end_y",
+        "description",
+        "uuid",
+    }

--- a/holonote/tests/test_annotators_basic.py
+++ b/holonote/tests/test_annotators_basic.py
@@ -344,3 +344,15 @@ def test_spec_datetime_date(conn_sqlite_uuid, dtype):
     output = annotator.df.dtypes
     assert output["start[time]"] == np.dtype("datetime64[ns]")
     assert output["end[time]"] == np.dtype("datetime64[ns]")
+
+
+def test_multiple_regions_one_first(multiple_annotators, conn_sqlite_uuid):
+    annotator = multiple_annotators
+
+    annotator.set_regions(TIME=(pd.Timestamp("2022-06-06"), pd.Timestamp("2022-06-08")))
+    annotator.add_annotation(description="Only time")
+    annotator.commit()
+
+    annotator.set_regions(x=(-0.25, 0.25), y=(-0.1, 0.1))
+    annotator.add_annotation(description="x and y")
+    annotator.commit()

--- a/holonote/tests/test_annotators_basic.py
+++ b/holonote/tests/test_annotators_basic.py
@@ -365,3 +365,11 @@ def test_multiple_regions_one_first(multiple_annotators):
         "description",
         "uuid",
     }
+
+
+def test_clear_region(multiple_annotators):
+    annotator = multiple_annotators
+
+    annotator.set_regions(TIME=(pd.Timestamp("2022-06-06"), pd.Timestamp("2022-06-08")))
+    annotator.add_annotation(description="Only time")
+    assert annotator._region == {}

--- a/holonote/tests/test_annotators_basic.py
+++ b/holonote/tests/test_annotators_basic.py
@@ -26,7 +26,7 @@ class TestBasicRange1DAnnotator:
         assert len(commits) == 1, "Only one insertion commit made "
         annotator_range1d.commit(return_commits=True)
         assert commits[0]["operation"] == "insert"
-        assert set(commits[0]["kwargs"].keys()) == set(annotator_range1d.connector.columns)
+        assert set(commits[0]["kwargs"]) == set(annotator_range1d.connector.column_schema)
 
     def test_range_insertion_values(self, annotator_range1d) -> None:
         start, end = np.datetime64("2022-06-06"), np.datetime64("2022-06-08")
@@ -92,7 +92,7 @@ class TestBasicRange2DAnnotator:
         commits = annotator_range2d.commit(return_commits=True)
         assert len(commits) == 1, "Only one insertion commit made "
         assert commits[0]["operation"] == "insert"
-        assert set(commits[0]["kwargs"].keys()) == set(annotator_range2d.connector.columns)
+        assert set(commits[0]["kwargs"]) == set(annotator_range2d.connector.column_schema)
 
     def test_range_insertion_values(self, annotator_range2d):
         startx, endx, starty, endy = -0.25, 0.25, -0.1, 0.1
@@ -160,7 +160,7 @@ class TestBasicPoint1DAnnotator:
         assert len(commits) == 1, "Only one insertion commit made "
         annotator_point1d.commit(return_commits=True)
         assert commits[0]["operation"] == "insert"
-        assert set(commits[0]["kwargs"].keys()) == set(annotator_point1d.connector.columns)
+        assert set(commits[0]["kwargs"]) == set(annotator_point1d.connector.column_schema)
 
     @pytest.mark.skip("Need to add validation to set_regions")
     def test_range_insertion_exception(self, annotator_point1d):
@@ -225,7 +225,7 @@ class TestBasicPoint2DAnnotator:
         commits = annotator_point2d.commit(return_commits=True)
         assert len(commits) == 1, "Only one insertion commit made "
         assert commits[0]["operation"] == "insert"
-        assert set(commits[0]["kwargs"].keys()) == set(annotator_point2d.connector.columns)
+        assert set(commits[0]["kwargs"]) == set(annotator_point2d.connector.column_schema)
 
     @pytest.mark.skip("Need to add validation to set_regions")
     def test_range_insertion_exception(self, annotator_point2d):


### PR DESCRIPTION
This PR does the following:

- Don't send `None` values to the database when adding rows. This is already done by the database.
- Remove the `columns` property.
- Fixes a bug where `AnnotatorInterface` did not clear the region after adding an annotation, this bug did not affect the `Annotator` when using an element. 

Based on the `use_context` PR.