### PR TITLE
Improve PanelWidgets with visible widget and make color deterministic

### DIFF
--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -297,7 +297,7 @@ class AnnotationDisplay(param.Parameterized):
     @classmethod
     def _infer_kdim_dtypes(cls, element):
         if not isinstance(element, hv.Element):
-            msg = "Supplied object {element} is not a bare HoloViews Element"
+            msg = f"Supplied object {element} is not a bare HoloViews Element"
             raise ValueError(msg)
         kdim_dtypes = {}
         for kdim in element.dimensions(selection="key"):

--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -119,7 +119,7 @@ class Style(param.Parameterized):
         select = {"alpha": (self.selection_alpha, self.alpha)}
         if self.selection_color is not None:
             if isinstance(self._color, hv.dim):
-                msg = "'Style.color' cannot be a `hv.dim` when 'Style.selection_color' is not None"
+                msg = "'Style.color' cannot be a `hv.dim` / `None` when 'Style.selection_color' is not None"
                 raise ValueError(msg)
             else:
                 select["color"] = (self.selection_color, self._color)

--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -9,6 +9,8 @@ import param
 from packaging.version import Version
 from panel.viewable import Viewer
 
+from ..annotate.display import _default_color
+
 if TYPE_CHECKING:
     from holonote.annotate import Annotator
 
@@ -50,7 +52,13 @@ class PanelWidgets(Viewer):
         if self.annotator.groupby is None:
             self.visible_widget = None
             return
-        if isinstance(colormap := self.annotator.style._colormap, dict):
+        style = self.annotator.style
+        if style.color is None and style._colormap is None:
+            data = sorted(self.annotator.df[self.annotator.groupby].unique())
+            colormap = dict(zip(data, _default_color))
+        else:
+            colormap = style._colormap
+        if isinstance(colormap, dict):
             stylesheet = """
             option:after {
               content: "";

--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -47,14 +47,38 @@ class PanelWidgets(Viewer):
         self._set_standard_callbacks()
 
     def _create_visible_widget(self):
-        if self.annotator.groupby is not None:
-            options = sorted(self.annotator.df[self.annotator.groupby].unique())
-            self.visible_widget = pn.widgets.MultiSelect(
-                name="Visible", options=options, value=self.annotator.visible or options
-            )
-            self.annotator.visible = self.visible_widget
-        else:
+        if self.annotator.groupby is None:
             self.visible_widget = None
+            return
+        if isinstance(colormap := self.annotator.style._colormap, dict):
+            stylesheet = """
+            option:after {
+              content: "";
+              width: 10px;
+              height: 10px;
+              position: absolute;
+              border-radius: 50%;
+              left: calc(100% - var(--design-unit, 4) * 2px - 3px);
+              top: 20%;
+              border: 1px solid black;
+              opacity: 0.5;
+            }"""
+            for i, color in enumerate(colormap.values()):
+                stylesheet += f"""
+            option:nth-child({i + 1}):after {{
+                background-color: {color};
+            }}"""
+        else:
+            stylesheet = ""
+
+        options = list(colormap)
+        self.visible_widget = pn.widgets.MultiSelect(
+            name="Visible",
+            options=options,
+            value=self.annotator.visible or options,
+            stylesheets=[stylesheet],
+        )
+        self.annotator.visible = self.visible_widget
 
     def _add_button_description(self):
         from bokeh.models import Tooltip

--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -42,8 +42,19 @@ class PanelWidgets(Viewer):
         else:
             self._fields_values = {k: field_values.get(k, "") for k in self.annotator.fields}
         self._fields_widgets = self._create_fields_widgets(self._fields_values)
+        self._create_visible_widget()
 
         self._set_standard_callbacks()
+
+    def _create_visible_widget(self):
+        if self.annotator.groupby is not None:
+            options = sorted(self.annotator.df[self.annotator.groupby].unique())
+            self.visible_widget = pn.widgets.MultiSelect(
+                name="Visible", options=options, value=self.annotator.visible or options
+            )
+            self.annotator.visible = self.visible_widget
+        else:
+            self.visible_widget = None
 
     def _add_button_description(self):
         from bokeh.models import Tooltip
@@ -181,4 +192,6 @@ class PanelWidgets(Viewer):
         self._widget_mode_group.param.watch(self._watcher_mode_group, "value")
 
     def __panel__(self):
-        return pn.Column(self.fields_widgets, self.tool_widgets)
+        if self.visible_widget is None:
+            return pn.Column(self.fields_widgets, self.tool_widgets)
+        return pn.Column(self.visible_widget, self.fields_widgets, self.tool_widgets)

--- a/holonote/tests/test_annotators_style.py
+++ b/holonote/tests/test_annotators_style.py
@@ -117,7 +117,7 @@ def test_style_error_color_dim_and_selection(cat_annotator):
         categories={"B": "red", "A": "blue", "C": "green"}, default="grey"
     )
     style.selection_color = "blue"
-    msg = r"'Style\.color' cannot be a `hv.dim` when 'Style.selection_color' is not None"
+    msg = "'Style.color' cannot be a `hv.dim` / `None` when 'Style.selection_color' is not None"
     with pytest.raises(ValueError, match=msg):
         compare_style(cat_annotator)
 

--- a/holonote/tests/test_annotators_style.py
+++ b/holonote/tests/test_annotators_style.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from holonote.annotate import Style
+from holonote.annotate.display import _default_color
 from holonote.tests.util import get_editor, get_indicator
 
 
@@ -10,12 +11,11 @@ def compare_indicator_color(indicator, style):
     if isinstance(indicator.opts["color"], hv.dim):
         if isinstance(style.color, hv.dim):
             assert str(indicator.opts["color"]) == str(style.color)
+        elif style.color is None and style._colormap:
+            assert dict(zip(style._groupby[1], _default_color)) == style._colormap
         else:
-            style_color = (
-                style.color.values[0] if isinstance(style.color, hv.Cycle) else style.color
-            )
             expected_dim = hv.dim("__selected__").categorize(
-                categories={True: style.selection_color}, default=style_color
+                categories={True: style.selection_color}, default=style.color
             )
             assert str(indicator.opts["color"]) == str(expected_dim)
     else:
@@ -157,6 +157,6 @@ def test_groupby_color_change(cat_annotator) -> None:
     cat_annotator.visible = ["A", "B", "C"]
 
     indicators = hv.render(cat_annotator.get_display("x").static_indicators()).renderers
-    color_cycle = cat_annotator.style.color.values
+    color_cycle = cat_annotator.style._colormap.values()
     for indicator, expected_color in zip(indicators, color_cycle):
         assert indicator.glyph.fill_color == expected_color

--- a/holonote/tests/test_annotators_style.py
+++ b/holonote/tests/test_annotators_style.py
@@ -86,6 +86,9 @@ def test_style_color_dim(cat_annotator):
     compare_style(cat_annotator)
 
 
+@pytest.mark.xfail(
+    reason="hv.dim is not supported for selection.color in the current implementation"
+)
 def test_style_selection_color(cat_annotator):
     style = cat_annotator.style
     style.selection_color = "blue"


### PR DESCRIPTION
Also, memorizing the color when using `groupby`  by using a dim expression instead of cycle.

https://github.com/holoviz/holonote/assets/19758978/c327741c-ed12-4797-83e6-e7a916ae6107



<details>
  <summary>Code </summary>

``` python
import hvplot.pandas
import pandas as pd
from holonote.annotate import Annotator, SQLiteDB
from holonote.app import PanelWidgets
import panel as pn

# Setup
speed_data = pd.read_parquet("../assets/example.parquet")
curve = speed_data.hvplot("TIME", "SPEED")

annotator = Annotator(
    curve,
    fields=["category"],
    connector=SQLiteDB(table_name="styling"),
)

start_time = pd.date_range("2022-06-04", "2022-06-22", periods=5)
end_time = start_time + pd.Timedelta(days=2)
data = {
    "start_time": start_time,
    "end_time": end_time,
    "category": ["A", "B", "A", "C", "B"],
}
annotator.define_annotations(pd.DataFrame(data), TIME=("start_time", "end_time"))

# News stuff
annotator.groupby = "category"
pn.Row(PanelWidgets(annotator), annotator * curve)
```

</details>