### PR TITLE
Use different icons

### DIFF
--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -33,9 +33,9 @@ class PanelWidgets(Viewer):
         self._widget_mode_group = pn.widgets.RadioButtonGroup(
             name="Mode", options=["+", "-", "✏"], width=90
         )
-        self._widget_apply_button = pn.widgets.Button(name="✓", width=20)
+        self._widget_apply_button = pn.widgets.Button(icon="device-floppy", width=20)
         self._widget_revert_button = pn.widgets.Button(name="↺", width=20)
-        self._widget_commit_button = pn.widgets.Button(name="▲", width=20)
+        self._widget_commit_button = pn.widgets.Button(icon="database", width=20)
         if PN13:
             self._add_button_description()
 


### PR DESCRIPTION
Jim mentioned that the checkmark wasn't intuitive; not sure if this is more intuitive.

<img width="338" alt="image" src="https://github.com/holoviz/holonote/assets/15331990/dfb317c4-5c70-45df-98cd-e9dbc59fc53f">

or

<img width="332" alt="image" src="https://github.com/holoviz/holonote/assets/15331990/388740a7-d45f-4c47-a4b3-74fc92a07dc6">

or
<img width="341" alt="image" src="https://github.com/holoviz/holonote/assets/15331990/9acbe269-4403-4431-8e51-0b089e5c2c9d">

