### PR TITLE
Fix visible indicator in Chrome

### DIFF
--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -98,7 +98,6 @@ class PanelWidgets(Viewer):
               position: absolute;
               border-radius: 50%;
               left: calc(100% - var(--design-unit, 4) * 2px - 3px);
-              top: 20%;
               border: 1px solid black;
               opacity: 0.5;
             }"""


### PR DESCRIPTION
Fixes #110 

Note that it showed all colors before but collapsed them into one location...

![image](https://github.com/holoviz/holonote/assets/19758978/111a67de-1a5a-45c0-b8b7-f2aef7057787)
