### PR TITLE
Conditionally invert axis to align annotations with elements

### DIFF
--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -491,7 +491,7 @@ class AnnotationDisplay(param.Parameterized):
             "data": self.data,
             "region_labels": region_labels,
             "fields_labels": fields_labels,
-            "invert_axes": self.invert_axis,
+            "invert_axes": self.invert_axis,  # Only handled for range1D
             "groupby": self.annotator.groupby,
         }
 

--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -208,7 +208,7 @@ class Indicator:
         """
         vdims = [*fields_labels, "__selected__"]
         ds = hv.Dataset(data, kdims=region_labels, vdims=vdims)
-        element = ds.to(hv.VSpans, groupby=groupby)
+        element = ds.to(hv.HSpans if invert_axes else hv.VSpans, groupby=groupby)
         hover = cls._build_hover_tool(data)
         return element.opts(tools=[hover])
 
@@ -235,6 +235,8 @@ class AnnotationDisplay(param.Parameterized):
     )
 
     data = param.DataFrame(doc="Combined dataframe of annotation data", constant=True)
+
+    invert_axis = param.Boolean(default=False, doc="Switch the annotation axis")
 
     _count = param.Integer(default=0, precedence=-1)
 
@@ -489,7 +491,7 @@ class AnnotationDisplay(param.Parameterized):
             "data": self.data,
             "region_labels": region_labels,
             "fields_labels": fields_labels,
-            "invert_axes": False,  # Not yet handled
+            "invert_axes": self.invert_axis,
             "groupby": self.annotator.groupby,
         }
 

--- a/holonote/tests/test_annotators_element.py
+++ b/holonote/tests/test_annotators_element.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 
 import holoviews as hv
+import numpy as np
 import pytest
 from holoviews.operation.datashader import rasterize
 
-from holonote.tests.util import get_editor, get_indicator
-
-
-def get_editor_data(annotator, element_type, kdims=None):
-    el = get_editor(annotator, element_type, kdims)
-    return getattr(el, "data", None)
-
-
-def get_indicator_data(annotator, element_type, kdims=None):
-    for el in get_indicator(annotator, element_type, kdims):
-        yield el.data
+from holonote.tests.util import (
+    get_display_data_from_plot,
+    get_editor_data,
+    get_indicator,
+    get_indicator_data,
+)
 
 
 def test_set_regions_range1d(annotator_range1d) -> None:
@@ -135,6 +131,64 @@ def test_set_regions_multiple(multiple_annotators):
     output2 = output.iloc[0]["description"]
     expected2 = "Test"
     assert output2 == expected2
+
+
+def test_single_shared_axis_hspan(annotator_range2d):
+    annotator = annotator_range2d
+    bounds = (-1, -1, 1, 1)
+    data = np.array([[0, 1], [1, 0]])
+    img = hv.Image(data, kdims=["x", "y"], bounds=bounds)
+    img_right = hv.Image(data, kdims=["z", "y"], bounds=bounds)  # y as second kdim! so HSpan
+
+    left_plot = annotator * img
+    right_plot = annotator * img_right
+    layout = left_plot + right_plot
+    hv.render(layout)
+
+    annotator.set_regions(x=(-0.15, 0.15), y=(-0.25, 0.25))
+    annotator.add_annotation(description="Test")
+
+    left_display_data = get_display_data_from_plot(left_plot, hv.Rectangles, ["x", "y"])
+    right_display_data = get_display_data_from_plot(right_plot, hv.HSpans, ["y"])
+
+    expected_left = [-0.15, -0.25, 0.15, 0.25]
+    assert (
+        left_display_data == expected_left
+    ), f"Expected {expected_left}, but got {left_display_data}"
+
+    expected_right = [-0.25, 0.25]
+    assert (
+        right_display_data == expected_right
+    ), f"Expected {expected_right}, but got {right_display_data}"
+
+
+def test_single_shared_axis_vspan(annotator_range2d):
+    annotator = annotator_range2d
+    bounds = (-1, -1, 1, 1)
+    data = np.array([[0, 1], [1, 0]])
+    img = hv.Image(data, kdims=["x", "y"], bounds=bounds)
+    img_right = hv.Image(data, kdims=["y", "z"], bounds=bounds)  # y as first kdim! so VSpan
+
+    left_plot = annotator * img
+    right_plot = annotator * img_right
+    layout = left_plot + right_plot
+    hv.render(layout)
+
+    annotator.set_regions(x=(-0.15, 0.15), y=(-0.25, 0.25))
+    annotator.add_annotation(description="Test")
+
+    left_display_data = get_display_data_from_plot(left_plot, hv.Rectangles, ["x", "y"])
+    right_display_data = get_display_data_from_plot(right_plot, hv.VSpans, ["y"])
+
+    expected_left = [-0.15, -0.25, 0.15, 0.25]
+    assert (
+        left_display_data == expected_left
+    ), f"Expected {expected_left}, but got {left_display_data}"
+
+    expected_right = [-0.25, 0.25]
+    assert (
+        right_display_data == expected_right
+    ), f"Expected {expected_right}, but got {right_display_data}"
 
 
 def test_editable_enabled(annotator_range1d):

--- a/holonote/tests/test_annotators_element.py
+++ b/holonote/tests/test_annotators_element.py
@@ -141,7 +141,7 @@ def test_single_shared_axis_hspan(annotator_range2d):
     bounds = (-1, -1, 1, 1)
     data = np.array([[0, 1], [1, 0]])
     img = hv.Image(data, kdims=["x", "y"], bounds=bounds)
-    img_right = hv.Image(data, kdims=["z", "y"], bounds=bounds)  # y as second kdim! so HSpan
+    img_right = hv.Image(data, kdims=["z", "y"], bounds=bounds)
 
     left_plot = annotator * img
     right_plot = annotator * img_right
@@ -170,7 +170,7 @@ def test_single_shared_axis_vspan(annotator_range2d):
     bounds = (-1, -1, 1, 1)
     data = np.array([[0, 1], [1, 0]])
     img = hv.Image(data, kdims=["x", "y"], bounds=bounds)
-    img_right = hv.Image(data, kdims=["y", "z"], bounds=bounds)  # y as first kdim! so VSpan
+    img_right = hv.Image(data, kdims=["y", "z"], bounds=bounds)
 
     left_plot = annotator * img
     right_plot = annotator * img_right

--- a/holonote/tests/util.py
+++ b/holonote/tests/util.py
@@ -19,6 +19,31 @@ def get_editor(annotator, element_type, kdims=None):
             return e
 
 
+def get_editor_data(annotator, element_type, kdims=None):
+    el = get_editor(annotator, element_type, kdims)
+    return getattr(el, "data", None)
+
+
 def get_indicator(annotator, element_type, kdims=None):
     si = _get_display(annotator, kdims).indicators().last
     yield from si.data.values()
+
+
+def get_indicator_data(annotator, element_type, kdims=None):
+    for el in get_indicator(annotator, element_type, kdims):
+        yield el.data
+
+
+def get_display_data_from_plot(plot, element_type, kdims):
+    display_data = None
+
+    for el in plot.traverse():
+        if isinstance(el, element_type):
+            display_data = getattr(el, "data", None)
+            break
+
+    if display_data is not None:
+        cols = [f"start[{dim}]" for dim in kdims] + [f"end[{dim}]" for dim in kdims]
+        display_data = display_data.iloc[0][cols].to_list()
+
+    return display_data


### PR DESCRIPTION
Fixes https://github.com/holoviz/holonote/issues/112

Invert axis if the first kdim of the element is not an annotator kdim, ensuring overlaying annotations align with underlying elements.

<details> <summary> Code </summary>

```python
import holoviews as hv; hv.extension('bokeh')
import panel as pn; pn.extension()
import numpy as np

from holonote.annotate import Annotator
from holonote.app import PanelWidgets

annotator = Annotator({"x": float, "y": float}, fields=["description"])
bounds = (-1, -1, 1, 1)
data = np.array([[0, 1], [1, 0]])
img = hv.Image(data, kdims=['x', 'y'], bounds=bounds)
img_right = hv.Image(data, kdims=['z', 'y'], bounds=bounds)  # y as second kdim! so HSpan

left_plot = annotator * img
right_plot = annotator * img_right
layout = left_plot + right_plot

annotator.set_regions(x=(-0.15, 0.15), y=(-0.25, 0.25))
annotator.add_annotation(description="Test")

layout
```

</details>

![image](https://github.com/holoviz/holonote/assets/6613202/5fb5ce2e-d1b7-40f0-b280-e65bf705e7e4)