### PR TITLE
Fix edit stream and make popup more robust

### DIFF
--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -251,7 +251,7 @@ class AnnotationDisplay(param.Parameterized):
 
         self._selection_info = {}
 
-        self._selection_enabled = True
+        self._selection_enabled = False
         self._editable_enabled = True
 
         transient = False
@@ -303,6 +303,7 @@ class AnnotationDisplay(param.Parameterized):
             tools.append(BoxSelectTool(dimensions="width"))
         elif self.region_format == "point-point":
             tools.append("tap")
+        tools.append("doubletap")
         return tools
 
     @classmethod
@@ -443,7 +444,7 @@ class AnnotationDisplay(param.Parameterized):
             else:
                 self.annotator.select_by_index()
 
-        self._tap_stream = hv.streams.Tap(source=element, transient=True)
+        self._tap_stream = hv.streams.Tap(source=element)
         self._tap_stream.add_subscriber(tap_selector)
         return element
 
@@ -451,7 +452,7 @@ class AnnotationDisplay(param.Parameterized):
         def double_tap_clear(x, y):
             self.clear_indicated_region()
 
-        self._double_tap_stream = hv.streams.DoubleTap(source=element, transient=True)
+        self._double_tap_stream = hv.streams.DoubleTap(source=element)
         self._double_tap_stream.add_subscriber(double_tap_clear)
         return element
 
@@ -473,6 +474,7 @@ class AnnotationDisplay(param.Parameterized):
             active_tools += ["box_select"]
         elif self.region_format == "point-point":
             active_tools += ["tap"]
+
         layers.append(self._element.opts(tools=self.edit_tools, active_tools=active_tools))
 
         if indicators:

--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -444,7 +444,7 @@ class AnnotationDisplay(param.Parameterized):
             else:
                 self.annotator.select_by_index()
 
-        self._tap_stream = hv.streams.Tap(source=element)
+        self._tap_stream = hv.streams.Tap(source=element, transient=True)
         self._tap_stream.add_subscriber(tap_selector)
         return element
 
@@ -452,7 +452,7 @@ class AnnotationDisplay(param.Parameterized):
         def double_tap_clear(x, y):
             self.clear_indicated_region()
 
-        self._double_tap_stream = hv.streams.DoubleTap(source=element)
+        self._double_tap_stream = hv.streams.DoubleTap(source=element, transient=True)
         self._double_tap_stream.add_subscriber(double_tap_clear)
         return element
 

--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -251,7 +251,7 @@ class AnnotationDisplay(param.Parameterized):
 
         self._selection_info = {}
 
-        self._selection_enabled = False
+        self._selection_enabled = True
         self._editable_enabled = True
 
         transient = False

--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -303,7 +303,6 @@ class AnnotationDisplay(param.Parameterized):
             tools.append(BoxSelectTool(dimensions="width"))
         elif self.region_format == "point-point":
             tools.append("tap")
-        tools.append("doubletap")
         return tools
 
     @classmethod

--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -224,57 +224,68 @@ class PanelWidgets(Viewer):
         elif self._widget_mode_group.value == "-" and selected_ind is not None:
             self.annotator.delete_annotation(selected_ind)
 
-    def _get_layout(self, name):
+    def _add_layout(self, name):
+        """
+        Add a layout to the panel, by cloning the root layout, linking the close button,
+        and returning it visibly.
+        """
+
         def close_layout(event):
             layout.visible = False
 
         layout = self._layouts.get(name)
         if not layout:
-            layout = self._layout.clone(visible=False)
+            layout = self._layout.clone(visible=True)
             self._widget_apply_button.on_click(close_layout)
             self._layouts[name] = layout
         return layout
 
-    def _hide_layouts(self):
-        for layout in self._layouts.values():
-            layout.visible = False
+    def _hide_layouts_except(self, desired_name) -> pn.Column:
+        """
+        Prevents multiple layouts from being visible at the same time.
+        """
+        desired_layout = None
+        with param.parameterized.batch_call_watchers(self):
+            for name, layout in self._layouts.items():
+                if name == desired_name:
+                    layout.visible = True
+                    desired_layout = layout
+                elif not name.startswith("panel"):
+                    layout.visible = False
+
+        # If the desired layout is not found, create it
+        if desired_name is not None and desired_layout is None:
+            desired_layout = self._add_layout(desired_name)
+        return desired_layout
 
     def _register_stream_popup(self, stream):
         def _popup(*args, **kwargs):
-            layout = self._get_layout(stream.name)
-            with param.parameterized.batch_call_watchers(self):
-                self._hide_layouts()
-                self._widget_mode_group.value = "+"
-                layout.visible = True
-                return layout
+            # If the annotation widgets are laid out on the side,
+            # do not show the popup when in subtract or edit mode
+            widgets_on_side = any(name.startswith("panel") for name in self._layouts)
+            if widgets_on_side and self._widget_mode_group.value in ("-", "✏"):
+                return
+            return self._hide_layouts_except(stream.name)
 
         stream.popup = _popup
 
     def _register_tap_popup(self, display):
         def tap_popup(x, y) -> None:  # Tap tool must be enabled on the element
-            layout = self._get_layout("tap")
-            if self.annotator.selection_enabled:
-                with param.parameterized.batch_call_watchers(self):
-                    self._hide_layouts()
-                    layout.visible = True
-                    return layout
+            if self.annotator.selected_indices:
+                return self._hide_layouts_except("tap")
 
         display._tap_stream.popup = tap_popup
 
     def _register_double_tap_clear(self, display):
         def double_tap_toggle(x, y):
-            layout = self._get_layout("doubletap")
-            if layout.visible:
-                with param.parameterized.batch_call_watchers(self):
-                    self._hide_layouts()
-                    layout.visible = True
-                    return layout
+            # Toggle the visibility of the doubletap layout
+            if any(layout.visible for layout in self._layouts.values()):
+                # Clear all open layouts
+                self._hide_layouts_except(None)
+            else:
+                # Open specifically the doubletap layout
+                return self._hide_layouts_except("doubletap")
 
-        try:
-            tools = display._element.opts["tools"]
-        except KeyError:
-            tools = []
-        display._element.opts(tools=[*tools, "doubletap"])
         display._double_tap_stream.popup = double_tap_toggle
 
     def _callback_commit(self, event):
@@ -284,7 +295,6 @@ class PanelWidgets(Viewer):
         if len(event.new) != 1:
             return
         selected_index = event.new[0]
-        # if self._widget_mode_group.value == '✏':
         for name, widget in self._fields_widgets.items():
             value = self.annotator.annotation_table._field_df.loc[selected_index][name]
             widget.value = value
@@ -293,6 +303,7 @@ class PanelWidgets(Viewer):
         with param.parameterized.batch_call_watchers(self):
             if event.new in ("-", "✏"):
                 self.annotator.selection_enabled = True
+                self.annotator.editable_enabled = False
             elif event.new == "+":
                 self.annotator.editable_enabled = True
                 self.annotator.selection_enabled = False
@@ -308,4 +319,6 @@ class PanelWidgets(Viewer):
         self._widget_mode_group.param.watch(self._watcher_mode_group, "value")
 
     def __panel__(self):
-        return self._layout.clone(visible=True)
+        layout = self._layout.clone(visible=True)
+        self._layouts["panel"] = layout
+        return layout

--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -265,6 +265,7 @@ class PanelWidgets(Viewer):
             widgets_on_side = any(name.startswith("panel") for name in self._layouts)
             if widgets_on_side and self._widget_mode_group.value in ("-", "✏"):
                 return
+            self._widget_mode_group.value = "+"
             return self._hide_layouts_except(stream.name)
 
         stream.popup = _popup


### PR DESCRIPTION
Closes https://github.com/holoviz/holonote/issues/114 and makes the popup more robust across another example (region 2d) not from the tutorial.

https://github.com/holoviz/holonote/assets/15331990/99497a05-f6b0-44b5-a217-af1b6952a48f


The clipping of the popup panel at the edge of the plot is a HoloViews/Bokeh issue that will be addressed separately.