### PR TITLE
Update visible UI from annotator events

### DIFF
--- a/holonote/annotate/display.py
+++ b/holonote/annotate/display.py
@@ -537,6 +537,9 @@ class AnnotationDisplay(param.Parameterized):
             msg = f"{self.region_format} not implemented"
             raise NotImplementedError(msg)
 
+        if len(indicator.data) == 0:
+            return hv.NdOverlay({0: self._make_empty_element()})
+
         if self.annotator.groupby and self.annotator.visible:
             indicator = indicator.get(self.annotator.visible)
             if indicator is None:
@@ -548,9 +551,6 @@ class AnnotationDisplay(param.Parameterized):
         highlight = self.style._indicator_selection
         highlighters = {opt: self._selected_dim_expr(v[0], v[1]) for opt, v in highlight.items()}
         indicator = indicator.opts(*self.style.indicator(**highlighters))
-
-        if len(indicator.data) == 0:
-            return hv.NdOverlay({0: self._make_empty_element()})
 
         return indicator.overlay() if self.annotator.groupby else hv.NdOverlay({0: indicator})
 

--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -138,8 +138,9 @@ class PanelWidgets(Viewer):
         if event.type == "create":
             new_option = event.fields[self.annotator.groupby]
             if new_option not in old_options:
-                self.visible_widget.options = sorted([*old_options, new_option])
-                self.visible_widget.value = [*old_values, new_option]
+                self.visible_widget.param.update(
+                    options=sorted([*old_options, new_option]), value=[*old_values, new_option]
+                )
             if new_option not in self.colormap:
                 if style.color is None:
                     # For now, we need to update the colormap so that

--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -4,6 +4,7 @@ import contextlib
 import datetime as dt
 from typing import TYPE_CHECKING, Any
 
+import holoviews as hv
 import panel as pn
 import param
 from packaging.version import Version
@@ -88,19 +89,17 @@ class PanelWidgets(Viewer):
         style = self.annotator.style
         self.colormap = {}
         all_options = sorted(set(self.annotator.df[self.annotator.groupby].unique()))
-        if all_options:
-            if style.color is None:
-                self.colormap = dict(zip(all_options, _default_color))
-            elif isinstance(style.color, str):
-                self.colormap = dict(zip(all_options, [style.color] * len(all_options)))
-            else:
-                self.colormap = self.annotator.style.color.ops[0]["kwargs"]["categories"]
-                # assign default to any unspecified options
-                for option in all_options:
-                    if option not in self.colormap:
-                        self.colormap[option] = self.annotator.style.color.ops[0]["kwargs"][
-                            "default"
-                        ]
+        # if all_options:
+        if style.color is None:
+            self.colormap = dict(zip(all_options, _default_color))
+        elif isinstance(style.color, str):
+            self.colormap = dict(zip(all_options, [style.color] * len(all_options)))
+        elif isinstance(style.color, hv.dim):
+            self.colormap = self.annotator.style.color.ops[0]["kwargs"]["categories"]
+            # assign default to any options whose color is unspecified by the user
+            for option in all_options:
+                if option not in self.colormap:
+                    self.colormap[option] = self.annotator.style.color.ops[0]["kwargs"]["default"]
 
         self._update_stylesheet()
         options = sorted(self.colormap.keys())
@@ -149,7 +148,7 @@ class PanelWidgets(Viewer):
                     self.colormap = dict(zip(new_options, _default_color))
                 elif isinstance(style.color, str):
                     self.colormap[new_option] = style.color
-                else:
+                elif isinstance(style.color, hv.dim):
                     self.colormap[new_option] = style.color.ops[0]["kwargs"]["default"]
                 self._update_stylesheet()
                 self.visible_widget.stylesheets = [self.stylesheet]
@@ -178,7 +177,7 @@ class PanelWidgets(Viewer):
                     self.colormap = dict(zip(new_options, _default_color))
                 elif isinstance(style.color, str):
                     self.colormap[new_option] = style.color
-                else:
+                elif isinstance(style.color, hv.dim):
                     # if it's a new annot type but color dim had been specified by the user, it would already
                     # be in the colormap, so otherwise set the new anno type to the default color
                     self.colormap[new_option] = style.color.ops[0]["kwargs"]["default"]

--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -88,21 +88,20 @@ class PanelWidgets(Viewer):
 
         style = self.annotator.style
         self.colormap = {}
-        all_options = sorted(set(self.annotator.df[self.annotator.groupby].unique()))
+        options = sorted(set(self.annotator.df[self.annotator.groupby].unique()))
         # if all_options:
         if style.color is None:
-            self.colormap = dict(zip(all_options, _default_color))
+            self.colormap = dict(zip(options, _default_color))
         elif isinstance(style.color, str):
-            self.colormap = dict(zip(all_options, [style.color] * len(all_options)))
+            self.colormap = dict(zip(options, [style.color] * len(options)))
         elif isinstance(style.color, hv.dim):
             self.colormap = self.annotator.style.color.ops[0]["kwargs"]["categories"]
             # assign default to any options whose color is unspecified by the user
-            for option in all_options:
+            for option in options:
                 if option not in self.colormap:
                     self.colormap[option] = self.annotator.style.color.ops[0]["kwargs"]["default"]
 
         self._update_stylesheet()
-        options = sorted(self.colormap.keys())
         self.visible_widget = pn.widgets.MultiSelect(
             name="Visible",
             options=options,

--- a/holonote/app/panel.py
+++ b/holonote/app/panel.py
@@ -112,16 +112,24 @@ class PanelWidgets(Viewer):
 
     def _update_stylesheet(self):
         self.stylesheet = """
+        option {
+        position: relative;
+        padding-left: 20px;
+        }
+
         option:after {
-          content: "";
-          width: 8px;
-          height: 8px;
-          position: absolute;
-          border-radius: 50%;
-          left: 1px;
-          border: 1px solid black;
-          opacity: 0.5;
-        }"""
+        content: "";
+        width: 8px;
+        height: 8px;
+        position: absolute;
+        border-radius: 50%;
+        left: 5px;
+        top: 50%; /* Align vertically */
+        transform: translateY(-50%); /* Align vertically */
+        border: 1px solid black;
+        opacity: 0.60;
+        }
+        """
         for _, (option, color) in enumerate(sorted(self.colormap.items())):
             self.stylesheet += f"""
         option[value="{option}"]:after {{

--- a/holonote/app/tabulator.py
+++ b/holonote/app/tabulator.py
@@ -38,8 +38,12 @@ class AnnotatorTable(pn.viewable.Viewer):
                 else:
                     field_dct[k] = v
 
-            self.annotator.annotation_table.update_annotation_region(spec_dct, row.name)
-            self.annotator.update_annotation_fields(row.name, **field_dct)
+            if "[" in event.column:
+                self.annotator.set_regions(**spec_dct)
+                self.annotator.update_annotation_region(row.name)
+                self.annotator.clear_regions()
+            else:
+                self.annotator.update_annotation_fields(row.name, **field_dct)
             self.annotator.refresh(clear=True)
 
             # So it is still reactive, as editing overwrites the table

--- a/holonote/tests/conftest.py
+++ b/holonote/tests/conftest.py
@@ -148,7 +148,6 @@ def cat_annotator(conn_sqlite_uuid) -> Annotator:
         groupby="category",
     )
     # Add data to annotator
-    # Ensure that 'C' only has a single data entry
     data = {
         "category": ["A", "B", "A", "C", "B"],
         "start_number": [1, 6, 11, 16, 21],

--- a/holonote/tests/conftest.py
+++ b/holonote/tests/conftest.py
@@ -148,6 +148,7 @@ def cat_annotator(conn_sqlite_uuid) -> Annotator:
         groupby="category",
     )
     # Add data to annotator
+    # Ensure that 'C' only has a single data entry
     data = {
         "category": ["A", "B", "A", "C", "B"],
         "start_number": [1, 6, 11, 16, 21],
@@ -155,6 +156,20 @@ def cat_annotator(conn_sqlite_uuid) -> Annotator:
         "description": list("ABCDE"),
     }
     annotator.define_annotations(pd.DataFrame(data), x=("start_number", "end_number"))
+    # Setup display
+    annotator.get_display("x")
+    return annotator
+
+
+@pytest.fixture()
+def cat_annotator_no_data(conn_sqlite_uuid) -> Annotator:
+    # Initialize annotator
+    annotator = Annotator(
+        {"x": float},
+        fields=["description", "category"],
+        connector=conn_sqlite_uuid,
+        groupby="category",
+    )
     # Setup display
     annotator.get_display("x")
     return annotator

--- a/holonote/tests/conftest.py
+++ b/holonote/tests/conftest.py
@@ -160,7 +160,7 @@ def cat_annotator(conn_sqlite_uuid) -> Annotator:
     return annotator
 
 
-@pytest.fixture()
+@pytest.fixture
 def cat_annotator_no_data(conn_sqlite_uuid) -> Annotator:
     # Initialize annotator
     annotator = Annotator(

--- a/holonote/tests/test_annotators_style.py
+++ b/holonote/tests/test_annotators_style.py
@@ -263,71 +263,70 @@ def test_style_selection_color(cat_annotator):
     sel_data = get_selected_indicator_data(cat_annotator)
     assert sel_data.sum() == 0
 
+    # Select the first value
+    index = cat_annotator.df.index[0]
+    cat_annotator.select_by_index(index)
+    compare_style(cat_annotator)
+    sel_data = get_selected_indicator_data(cat_annotator)
+    assert sel_data[index]
+    assert sel_data.sum() == 1
 
-#     # Select the first value
-#     index = cat_annotator.df.index[0]
-#     cat_annotator.select_by_index(index)
-#     compare_style(cat_annotator)
-#     sel_data = get_selected_indicator_data(cat_annotator)
-#     assert sel_data[index]
-#     assert sel_data.sum() == 1
-
-#     # remove it again
-#     cat_annotator.select_by_index()
-#     compare_style(cat_annotator)
-#     sel_data = get_selected_indicator_data(cat_annotator)
-#     assert sel_data.sum() == 0
-
-
-# def test_style_error_color_dim_and_selection(cat_annotator):
-#     style = cat_annotator.style
-#     style.color = hv.dim("category").categorize(
-#         categories={"B": "red", "A": "blue", "C": "green"}, default="grey"
-#     )
-#     style.selection_color = "blue"
-#     msg = "'Style.color' cannot be a `hv.dim` / `None` when 'Style.selection_color' is not None"
-#     with pytest.raises(ValueError, match=msg):
-#         compare_style(cat_annotator)
+    # remove it again
+    cat_annotator.select_by_index()
+    compare_style(cat_annotator)
+    sel_data = get_selected_indicator_data(cat_annotator)
+    assert sel_data.sum() == 0
 
 
-# def test_style_opts(cat_annotator):
-#     cat_annotator.style.opts = {"line_width": 2}
-#     compare_style(cat_annotator)
-
-#     indicator = next(get_indicator(cat_annotator, hv.VSpans))
-#     assert indicator.opts["line_width"] == 2
-
-#     editor = get_editor(cat_annotator, hv.VSpan)
-#     assert "line_width" not in editor.opts.get().kwargs
-
-#     cat_annotator.style.edit_opts = {"line_width": 3}
-#     cat_annotator.set_regions(x=(0, 1))  # To update plot
-#     editor = get_editor(cat_annotator, hv.VSpan)
-#     assert editor.opts["line_width"] == 3
+def test_style_error_color_dim_and_selection(cat_annotator):
+    style = cat_annotator.style
+    style.color = hv.dim("category").categorize(
+        categories={"B": "red", "A": "blue", "C": "green"}, default="grey"
+    )
+    style.selection_color = "blue"
+    msg = "'Style.color' cannot be a `hv.dim` / `None` when 'Style.selection_color' is not None"
+    with pytest.raises(ValueError, match=msg):
+        compare_style(cat_annotator)
 
 
-# @pytest.mark.parametrize("opts", [{"alpha": 0.5}, {"color": "red"}], ids=["alpha", "color"])
-# def test_style_opts_warn(cat_annotator, opts):
-#     msg = "Color and alpha opts should be set directly on the style object"
-#     with pytest.raises(UserWarning, match=msg):
-#         cat_annotator.style.opts = opts
+def test_style_opts(cat_annotator):
+    cat_annotator.style.opts = {"line_width": 2}
+    compare_style(cat_annotator)
+
+    indicator = next(get_indicator(cat_annotator, hv.VSpans))
+    assert indicator.opts["line_width"] == 2
+
+    editor = get_editor(cat_annotator, hv.VSpan)
+    assert "line_width" not in editor.opts.get().kwargs
+
+    cat_annotator.style.edit_opts = {"line_width": 3}
+    cat_annotator.set_regions(x=(0, 1))  # To update plot
+    editor = get_editor(cat_annotator, hv.VSpan)
+    assert editor.opts["line_width"] == 3
 
 
-# def test_style_reset(cat_annotator) -> None:
-#     style = cat_annotator.style
-#     style.color = "blue"
-#     compare_style(cat_annotator)
-
-#     style.reset()
-#     assert style.color == Style.color
-#     compare_style(cat_annotator)
+@pytest.mark.parametrize("opts", [{"alpha": 0.5}, {"color": "red"}], ids=["alpha", "color"])
+def test_style_opts_warn(cat_annotator, opts):
+    msg = "Color and alpha opts should be set directly on the style object"
+    with pytest.raises(UserWarning, match=msg):
+        cat_annotator.style.opts = opts
 
 
-# def test_groupby_color_change(cat_annotator) -> None:
-#     cat_annotator.groupby = "category"
-#     cat_annotator.visible = ["A", "B", "C"]
+def test_style_reset(cat_annotator) -> None:
+    style = cat_annotator.style
+    style.color = "blue"
+    compare_style(cat_annotator)
 
-#     indicators = hv.render(cat_annotator.get_display("x").static_indicators()).renderers
-#     color_cycle = cat_annotator.style._colormap.values()
-#     for indicator, expected_color in zip(indicators, color_cycle):
-#         assert indicator.glyph.fill_color == expected_color
+    style.reset()
+    assert style.color == Style.color
+    compare_style(cat_annotator)
+
+
+def test_groupby_color_change(cat_annotator) -> None:
+    cat_annotator.groupby = "category"
+    cat_annotator.visible = ["A", "B", "C"]
+
+    indicators = hv.render(cat_annotator.get_display("x").static_indicators()).renderers
+    color_cycle = cat_annotator.style._colormap.values()
+    for indicator, expected_color in zip(indicators, color_cycle):
+        assert indicator.glyph.fill_color == expected_color

--- a/holonote/tests/test_annotators_style.py
+++ b/holonote/tests/test_annotators_style.py
@@ -4,6 +4,7 @@ import pytest
 
 from holonote.annotate import Style
 from holonote.annotate.display import _default_color
+from holonote.app.panel import PanelWidgets
 from holonote.tests.util import get_editor, get_indicator
 
 
@@ -39,6 +40,128 @@ def compare_style(cat_annotator):
 def get_selected_indicator_data(annotator) -> pd.Series:
     df = pd.concat([i.data for i in get_indicator(annotator, hv.VLines)])
     return df["__selected__"]
+
+
+def test_color_undefined_resorting_nodatainit(cat_annotator_no_data):
+    annotator = cat_annotator_no_data
+    panel_widgets = PanelWidgets(annotator)
+
+    # Add a new annotation type 'A'
+
+    annotator.set_regions(x=(0, 1))
+    annotator.add_annotation(category="A")
+    annotator.commit()
+
+    compare_style(cat_annotator_no_data)
+    visible_options = panel_widgets.visible_widget.options
+    colormap = panel_widgets.colormap
+
+    assert "A" in visible_options, "New annotation type 'A' should be in visible options"
+    assert (
+        colormap["A"] == _default_color[0]
+    ), f"Expected default color for 'A', but got {colormap['A']}"
+
+    # Add a new annotation type 'C'
+
+    annotator.set_regions(x=(0, 1))
+    annotator.add_annotation(category="C")
+    annotator.commit()
+
+    compare_style(annotator)
+    visible_options = panel_widgets.visible_widget.options
+    colormap = panel_widgets.colormap
+
+    assert "C" in visible_options, "New annotation type 'C' should be in visible options"
+    assert (
+        colormap["C"] == _default_color[1]
+    ), f"Expected default color for 'C', but got {colormap['C']}"
+
+    # Add a new annotation type 'B' which resorts the order (A-B-C) of the options and therefore colormap
+
+    annotator.set_regions(x=(0, 1))
+    annotator.add_annotation(category="B")
+    annotator.commit()
+
+    compare_style(annotator)
+    visible_options = panel_widgets.visible_widget.options
+    colormap = panel_widgets.colormap
+
+    assert "B" in visible_options, "New annotation type 'B' should be in visible options"
+    assert (
+        colormap["B"] == _default_color[1]
+    ), f"Expected default color for 'B', but got {colormap['B']}"
+    assert (
+        colormap["C"] == _default_color[2]
+    ), f"Expected default color for 'C', but got {colormap['C']}"
+
+    # Remove the annotation type 'B', which again resorts the order of the options and assigned colormap
+
+    b_index = annotator.df[annotator.df["category"] == "B"].index[0]
+    annotator.delete_annotation(b_index)
+    annotator.commit()
+
+    compare_style(annotator)
+    visible_options = panel_widgets.visible_widget.options
+    colormap = panel_widgets.colormap
+
+    assert (
+        "B" not in visible_options
+    ), "Removed annotation type 'B' should not be in visible options"
+    assert (
+        colormap["A"] == _default_color[0]
+    ), f"Expected default color for 'A', but got {colormap['A']}"
+    assert (
+        colormap["C"] == _default_color[1]
+    ), f"Expected default color for 'C', but got {colormap['C']}"
+
+
+def test_color_dim_defined(cat_annotator):
+    annotator = cat_annotator
+    color_dim = hv.dim("category").categorize(
+        categories={"A": "purple", "B": "orange", "C": "green"}, default="grey"
+    )
+    annotator.style.color = color_dim
+    panel_widgets = PanelWidgets(annotator)
+
+    compare_style(annotator)
+
+    # Add a new annotation type 'D'
+    annotator.set_regions(x=(3, 4))
+    annotator.add_annotation(category="D")
+    annotator.commit()
+
+    compare_style(annotator)
+    visible_options = panel_widgets.visible_widget.options
+    colormap = panel_widgets.colormap
+
+    assert "D" in visible_options, "New annotation type 'D' should be in visible options"
+    assert (
+        colormap["D"] == "grey"
+    ), f"Expected default color 'grey' for 'D', but got {colormap['D']}"
+
+    # Delete annotation type 'C', which only has a single data entry
+    c_index = annotator.df[annotator.df["category"] == "C"].index[0]
+    annotator.delete_annotation(c_index)
+    annotator.commit()
+
+    compare_style(annotator)
+    visible_options = panel_widgets.visible_widget.options
+    colormap = panel_widgets.colormap
+
+    assert (
+        "C" not in visible_options
+    ), "Removed annotation type 'C' should not be in visible options"
+
+    # Add annotation type 'C' again
+    annotator.set_regions(x=(0, 1))
+    annotator.add_annotation(category="C")
+    annotator.commit()
+
+    compare_style(annotator)
+    visible_options = panel_widgets.visible_widget.options
+    colormap = panel_widgets.colormap
+
+    assert colormap["C"] == "green", f"Expected color 'green' for 'C', but got {colormap['C']}"
 
 
 def test_style_accessor(cat_annotator) -> None:
@@ -96,70 +219,71 @@ def test_style_selection_color(cat_annotator):
     sel_data = get_selected_indicator_data(cat_annotator)
     assert sel_data.sum() == 0
 
-    # Select the first value
-    index = cat_annotator.df.index[0]
-    cat_annotator.select_by_index(index)
-    compare_style(cat_annotator)
-    sel_data = get_selected_indicator_data(cat_annotator)
-    assert sel_data[index]
-    assert sel_data.sum() == 1
 
-    # remove it again
-    cat_annotator.select_by_index()
-    compare_style(cat_annotator)
-    sel_data = get_selected_indicator_data(cat_annotator)
-    assert sel_data.sum() == 0
+#     # Select the first value
+#     index = cat_annotator.df.index[0]
+#     cat_annotator.select_by_index(index)
+#     compare_style(cat_annotator)
+#     sel_data = get_selected_indicator_data(cat_annotator)
+#     assert sel_data[index]
+#     assert sel_data.sum() == 1
 
-
-def test_style_error_color_dim_and_selection(cat_annotator):
-    style = cat_annotator.style
-    style.color = hv.dim("category").categorize(
-        categories={"B": "red", "A": "blue", "C": "green"}, default="grey"
-    )
-    style.selection_color = "blue"
-    msg = "'Style.color' cannot be a `hv.dim` / `None` when 'Style.selection_color' is not None"
-    with pytest.raises(ValueError, match=msg):
-        compare_style(cat_annotator)
+#     # remove it again
+#     cat_annotator.select_by_index()
+#     compare_style(cat_annotator)
+#     sel_data = get_selected_indicator_data(cat_annotator)
+#     assert sel_data.sum() == 0
 
 
-def test_style_opts(cat_annotator):
-    cat_annotator.style.opts = {"line_width": 2}
-    compare_style(cat_annotator)
-
-    indicator = next(get_indicator(cat_annotator, hv.VSpans))
-    assert indicator.opts["line_width"] == 2
-
-    editor = get_editor(cat_annotator, hv.VSpan)
-    assert "line_width" not in editor.opts.get().kwargs
-
-    cat_annotator.style.edit_opts = {"line_width": 3}
-    cat_annotator.set_regions(x=(0, 1))  # To update plot
-    editor = get_editor(cat_annotator, hv.VSpan)
-    assert editor.opts["line_width"] == 3
+# def test_style_error_color_dim_and_selection(cat_annotator):
+#     style = cat_annotator.style
+#     style.color = hv.dim("category").categorize(
+#         categories={"B": "red", "A": "blue", "C": "green"}, default="grey"
+#     )
+#     style.selection_color = "blue"
+#     msg = "'Style.color' cannot be a `hv.dim` / `None` when 'Style.selection_color' is not None"
+#     with pytest.raises(ValueError, match=msg):
+#         compare_style(cat_annotator)
 
 
-@pytest.mark.parametrize("opts", [{"alpha": 0.5}, {"color": "red"}], ids=["alpha", "color"])
-def test_style_opts_warn(cat_annotator, opts):
-    msg = "Color and alpha opts should be set directly on the style object"
-    with pytest.raises(UserWarning, match=msg):
-        cat_annotator.style.opts = opts
+# def test_style_opts(cat_annotator):
+#     cat_annotator.style.opts = {"line_width": 2}
+#     compare_style(cat_annotator)
+
+#     indicator = next(get_indicator(cat_annotator, hv.VSpans))
+#     assert indicator.opts["line_width"] == 2
+
+#     editor = get_editor(cat_annotator, hv.VSpan)
+#     assert "line_width" not in editor.opts.get().kwargs
+
+#     cat_annotator.style.edit_opts = {"line_width": 3}
+#     cat_annotator.set_regions(x=(0, 1))  # To update plot
+#     editor = get_editor(cat_annotator, hv.VSpan)
+#     assert editor.opts["line_width"] == 3
 
 
-def test_style_reset(cat_annotator) -> None:
-    style = cat_annotator.style
-    style.color = "blue"
-    compare_style(cat_annotator)
-
-    style.reset()
-    assert style.color == Style.color
-    compare_style(cat_annotator)
+# @pytest.mark.parametrize("opts", [{"alpha": 0.5}, {"color": "red"}], ids=["alpha", "color"])
+# def test_style_opts_warn(cat_annotator, opts):
+#     msg = "Color and alpha opts should be set directly on the style object"
+#     with pytest.raises(UserWarning, match=msg):
+#         cat_annotator.style.opts = opts
 
 
-def test_groupby_color_change(cat_annotator) -> None:
-    cat_annotator.groupby = "category"
-    cat_annotator.visible = ["A", "B", "C"]
+# def test_style_reset(cat_annotator) -> None:
+#     style = cat_annotator.style
+#     style.color = "blue"
+#     compare_style(cat_annotator)
 
-    indicators = hv.render(cat_annotator.get_display("x").static_indicators()).renderers
-    color_cycle = cat_annotator.style._colormap.values()
-    for indicator, expected_color in zip(indicators, color_cycle):
-        assert indicator.glyph.fill_color == expected_color
+#     style.reset()
+#     assert style.color == Style.color
+#     compare_style(cat_annotator)
+
+
+# def test_groupby_color_change(cat_annotator) -> None:
+#     cat_annotator.groupby = "category"
+#     cat_annotator.visible = ["A", "B", "C"]
+
+#     indicators = hv.render(cat_annotator.get_display("x").static_indicators()).renderers
+#     color_cycle = cat_annotator.style._colormap.values()
+#     for indicator, expected_color in zip(indicators, color_cycle):
+#         assert indicator.glyph.fill_color == expected_color


### PR DESCRIPTION
Fixes https://github.com/holoviz/holonote/issues/124

Previously, the PanelWidgets' Visibility UI did not update when new annotations were added/removed/changed. This PR attempts to synchronize the visibility UI with annotator events: create, delete, and update (edit).

I've also changed how tabulator on_edit triggers events.. previously any change was triggering both field and region update events, and now it's either one xor the other.

I've also moved the legend color circles to the left of the visibility UI instead of the right, given that if you added more than 4 groupby field types, then a scrollbar appears and obscures the legend color circles on the right. The aesthetics of this can still be much improved, but at least it's not interfering now.

TODO: 
- [x] Fix coloring. ~~Make annotator glyph coloring to respect the new persistent approach - (a new groupby field value gets assigned a color and it will stay that color regardless if you delete all the annotations of that field value and then create more).~~ Instead of the persistent approach (saved for a future discussion/PR), I'm now just following what the annotation glyphs are doing.. essentially annotation groups (if color is unspecified by the user) will change color based on sorted order.
- [x] add tests


<details> <summary> Code </summary>

```python
 
 
from holonote.annotate import Annotator 
from holonote.app.tabulator import AnnotatorTable 
from holonote.app import PanelWidgets  
import panel as pn; pn.extension('tabulator')
import holoviews as hv; hv.extension('bokeh')
from holonote.annotate.connector import SQLiteDB

annotator = Annotator({"height": float, "width": float}, fields=["type"],
                      connector=SQLiteDB(filename=':memory:'))
annotator.groupby = "type"
annotator_widgets = pn.Column(PanelWidgets(annotator), AnnotatorTable(annotator))

pn.Column(annotator_widgets, annotator * hv.Image([], ['width', 'height'])).servable()
```

</details>


## Basic Functionality working pretty well:
https://github.com/holoviz/holonote/assets/6613202/e55df6a6-9902-4dc7-bf20-8a11d7e1e128