### PR TITLE
Add support for custom tabulator options

### DIFF
--- a/holonote/app/tabulator.py
+++ b/holonote/app/tabulator.py
@@ -14,11 +14,13 @@ class AnnotatorTable(pn.viewable.Viewer):
     annotator = param.Parameter(allow_refs=False)
     tabulator = param.Parameter(allow_refs=False)
     dataframe = param.DataFrame()
+    tabulator_kwargs = param.Dict(
+        default={}, doc="""Configurations for the HoloViz Panel Tabulator widget""", precedence=-1
+    )
 
     _updating = False
 
     def __init__(self, annotator, **params):
-        self.tabulator_kwargs = params.pop("tabulator_kwargs", {})
         super().__init__(annotator=annotator, **params)
         annotator.snapshot()
         self._create_tabulator()

--- a/holonote/app/tabulator.py
+++ b/holonote/app/tabulator.py
@@ -14,9 +14,7 @@ class AnnotatorTable(pn.viewable.Viewer):
     annotator = param.Parameter(allow_refs=False)
     tabulator = param.Parameter(allow_refs=False)
     dataframe = param.DataFrame()
-    tabulator_kwargs = param.Dict(
-        default={}, doc="""Configurations for the HoloViz Panel Tabulator widget""", precedence=-1
-    )
+    tabulator_kwargs = param.Dict(default={}, doc="kwargs to pass to tabulator", allow_refs=True)
 
     _updating = False
 
@@ -64,7 +62,7 @@ class AnnotatorTable(pn.viewable.Viewer):
             buttons={"delete": '<i class="fa fa-trash"></i>'},
             show_index=False,
             selectable=True,
-            **self.tabulator_kwargs,
+            refs=self.param.tabulator_kwargs,
         )
         self.tabulator.on_edit(on_edit)
         self.tabulator.on_click(on_click)

--- a/holonote/app/tabulator.py
+++ b/holonote/app/tabulator.py
@@ -18,6 +18,7 @@ class AnnotatorTable(pn.viewable.Viewer):
     _updating = False
 
     def __init__(self, annotator, **params):
+        self.tabulator_kwargs = params.pop("tabulator_kwargs", {})
         super().__init__(annotator=annotator, **params)
         annotator.snapshot()
         self._create_tabulator()
@@ -61,6 +62,7 @@ class AnnotatorTable(pn.viewable.Viewer):
             buttons={"delete": '<i class="fa fa-trash"></i>'},
             show_index=False,
             selectable=True,
+            **self.tabulator_kwargs,
         )
         self.tabulator.on_edit(on_edit)
         self.tabulator.on_click(on_click)


### PR DESCRIPTION
Fixes #125 

Use `tabulator_kwargs` and refer to the options https://panel.holoviz.org/reference/widgets/Tabulator.html

TODO:
- [ ] ~~allow for `show_indices` to be overwritten~~ (another PR)


For instance:
```python
AnnotatorTable(annotator, tabulator_kwargs=dict(pagination='local', page_size=7))
```

<details> <summary> Code </summary>

```python
import panel as pn
import holoviews as hv
hv.extension('bokeh')
import pandas as pd
from holonote.annotate import Annotator
from holonote.annotate.connector import SQLiteDB
from holonote.app import PanelWidgets, AnnotatorTable

data = {
    'description': ['T0', 'T1', 'T2'] * 10,
    'start': range(30),
    'end': [i + .8 for i in range(30)]
}

annotations_df = pd.DataFrame(data)

curve_data = {
    'time': range(30),
    'val': [1, 3, 2] * 10,
}

curve_df = pd.DataFrame(curve_data)

plot = hv.Curve(curve_df, 'time', 'val')

annotator = Annotator({'time': float}, fields=["description"],
                      connector=SQLiteDB(filename=':memory:')
                     )

annotator.define_annotations(annotations_df, time=("start", "end"))

annotator.groupby = "description"
annotator.visible = ["T1"]

annotator_widgets = pn.Column(
    PanelWidgets(annotator),
    AnnotatorTable(
        annotator,
        tabulator_kwargs=dict(
            pagination='local',
            page_size=7,
        )
    ),
    width=400
)

# Display the widgets and plot
pn.Row(annotator_widgets, annotator * plot.opts(responsive=True)).servable()

```

</details>